### PR TITLE
Add one test for RunModel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'com.google.guava:guava:28.0-jre'
 
     // Use JUnit test framework
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
 }
 
 

--- a/src/main/java/uk/co/ramp/covid/simulation/RunModel.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/RunModel.java
@@ -46,19 +46,23 @@ mModel.runTest();
         p.timeStep(300);
     }
 
+    public ArrayList<String> oneBaselineIter(int populationSize, int nHousehold, int nInfections, int nDays) {
+        Population p = new Population(populationSize, nHousehold);
+        p.populateHouseholds();
+        p.summarisePop();
+        p.createMixing();
+        p.allocatePeople();
+        p.seedVirus(nInfections);
+
+        return p.timeStep(nDays);
+    }
+
     public void runBaseline() throws Exception { // Run and output the baseline scenarios - with no lockdown
         ReadWrite rw = new ReadWrite("ModelOutputs//Baseline20200429//BaselineOut.csv");
         rw.openWritemodel();
         int nIter = 100;
         for (int i = 1; i <= nIter; i++) {
-            Population p = new Population(25000, 7500);
-            p.populateHouseholds();
-            p.summarisePop();
-            p.createMixing();
-            p.allocatePeople();
-            p.seedVirus(10);
-
-            ArrayList<String> vNext = p.timeStep(365);
+            ArrayList<String> vNext = oneBaselineIter(25000, 7500, 10, 365);
             for (String s : vNext) rw.writemodel(i, s);
         }
 

--- a/src/test/java/uk/co/ramp/covid/simulation/RunModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/RunModelTest.java
@@ -1,0 +1,70 @@
+package uk.co.ramp.covid.simulation;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class RunModelTest {
+
+    RunModel mModel = new RunModel();
+
+    class OutputForOneDay {
+        private int[] values;
+
+        public OutputForOneDay(String line) {
+            values = Arrays.asList(line.split(",")).stream().mapToInt(s -> Integer.parseInt(s)).toArray();
+        }
+
+        public int getDay() {
+            return values[0];
+        }
+
+        public int getHealthy() {
+            return values[1];
+        }
+
+        public int getDead() {
+            return values[6];
+        }
+
+        public int getRecovered() {
+            return values[7];
+        }
+
+        public int getTotalInfected() {
+            return values[2] + values[3] + values[4] + values[5];
+        }
+
+        public int getTotalPopulation() {
+            int sum = 0;
+            for (int i = 1; i < values.length; i++)
+                sum += values[i];
+            return sum;
+        }
+    }
+
+    @Test
+    public void testOneBaselineIter() {
+        int populationSize = 10000;
+        int nHouseholds = 3000;
+        int nInfections = 10;
+        ArrayList<String> vNext = mModel.oneBaselineIter(populationSize, nHouseholds, nInfections, 90);
+
+        OutputForOneDay output;
+        int lastTotalInfected = nInfections;
+        for (String s : vNext) {
+            output = new OutputForOneDay(s);
+            Assert.assertEquals(populationSize, output.getTotalPopulation());
+            Assert.assertTrue(output.getDead() <= output.getRecovered() * 0.1);
+            Assert.assertTrue(output.getDead() + nInfections >= output.getRecovered() * 0.005);
+            Assert.assertTrue(output.getTotalInfected() < lastTotalInfected * 2);
+            lastTotalInfected = output.getTotalInfected();
+
+            System.out.println(output.getDead() * 100.0 / output.getRecovered());
+        }
+
+        Assert.assertTrue(true);
+    }
+}


### PR DESCRIPTION
I have started looking into adding some basic high-level tests, and am adding this PR for discussion.

I think the code needs refactoring to make tests like this easier to write (e.g. with methods returning structured objects rather than comma separated strings).

Until the use of random number generator is changed, this test will not be repeatable.  I think that on one trial run, `Assert.assertEquals(populationSize, output.getTotalPopulation());` failed, but I'm not sure, and when I reran the test there were no problems.