### PR TITLE
Unify the Handling of Places

### DIFF
--- a/parameters/PopulationParameters.md
+++ b/parameters/PopulationParameters.md
@@ -113,16 +113,17 @@ distributions only need to account for household sizes greater than 1.
 | childAllocationPMap     | Probability map for adding additional children to households   | Map (householdSize : probability) |
 | infantAllocationPMap    | Probability map for adding additional infants to households    | Map (householdSize : probability) |
 
-## Neighbour Properties
+## Household Properties
 
-Determines the number and expected visit rate of neighbours
+Determines the number and expected visit/leave rate of neighbours
 
--   Object name: `neighbourProperties`
+-   Object name: `householdProperties`
 
-| Parameter Name     | Description                              | Type   |
-|--------------------|------------------------------------------|--------|
-| visitFrequency     | Probability a neighbour visits in a hour | Double |
-| expectedNeighbours | Expected (Poisson) number of neighbours  | Int    |
+| Parameter Name     | Description                                             | Type   |
+|--------------------|---------------------------------------------------------|--------|
+| visitFrequency     | Probability a neighbour visits in a hour                | Double |
+| expectedNeighbours | Expected (Poisson) number of neighbours                 | Int    |
+| visitorLeaveRate   | The chance, per hour, that a visitor leaves a household | Double |
 
 ## Building Distributions
 

--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -95,13 +95,14 @@
         "infantAllocation":{
             "pAttendsNursery":0.5
         },
-        "neighbourProperties":{
+        "householdProperties":{
             "neighbourVisitFreq":0.006,
+            "visitorLeaveRate":0.5,
             "expectedNeighbours":3
         },
         "personProperties":{
             "pTransmission":0.45,
             "pQuarantine":0.9
-        }
+        },
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/DailyStats.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/DailyStats.java
@@ -58,7 +58,7 @@ public class DailyStats {
             case PHASE1: phase1++; break;
             case PHASE2: phase2++; break;
             case RECOVERED: recovered++; break;
-            default: LOGGER.info("Invalid Status"); break;
+            case DEAD: dead++; break;
         }
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -23,7 +23,6 @@ public abstract class CommunalPlace {
 
     abstract public void reportInfection(DailyStats s);
 
-    private int cIndex;
     protected int startTime;
     protected int endTime;
     protected ArrayList<Person> listPeople;
@@ -35,14 +34,13 @@ public abstract class CommunalPlace {
     private double sDistance; // A social distancing coefficient;
     protected final RandomDataGenerator rng;
 
-    public CommunalPlace(int cIndex) {
+    public CommunalPlace() {
         this.rng = RNG.get();
         this.listPeople = new ArrayList<>();
         this.startTime = 8; // The hour of the day that the Communal Place starts
         this.endTime = 17; // The hour of the day that it ends
         this.startDay = 1; // Days of the week that it is active - start
         this.endDay = 5; // Days of the week that it is active - end
-        this.cIndex = cIndex; // This sets the index for each Communal Place to avoid searching
         this.transProb = PopulationParameters.get().getpBaseTrans(); // Pretty important parameter. This defines the transmission rate within this Communal Place
         this.keyProb = 1.0;
         this.sDistance = 1.0;
@@ -52,14 +50,6 @@ public abstract class CommunalPlace {
 
     public void overrideKeyPremises(boolean overR) {
         this.keyPremises = overR;
-    }
-
-    public int getIndex() {
-        return this.cIndex;
-    }
-
-    public void setIndex(int indexVal) {
-        this.cIndex = indexVal;
     }
 
     // Check whether a Person might visit at that hour of the day

--- a/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
@@ -5,8 +5,7 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 public class ConstructionSite extends CommunalPlace {
 
-    public ConstructionSite(int cindex) {
-        super(cindex);
+    public ConstructionSite() {
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpConstructionSiteTrans();
         keyProb = PopulationParameters.get().getpConstructionSiteKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -5,8 +5,7 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 public class Hospital extends CommunalPlace {
 
-    public Hospital(int cindex) {
-        super(cindex);
+    public Hospital() {
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpHospitalTrans();
         startDay = 3; //Bodge set start day to a different day of the week to help syncing
         endDay = 7;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -170,4 +170,20 @@ public class Household extends Place {
     public void reportInfection(DailyStats s) {
         s.incInfectionsHome();
     }
+
+    // For each household processes any movements to Communal Places that are relevant
+    public void cycleMovements(int day, int hour, boolean lockdown) {
+        List<Person> left = new ArrayList<>();
+        int i = 0;
+        for (Person p : vPeople) {
+            if (p.hasPrimaryCommunalPlace() && !p.getQuarantine()) {
+                boolean visit = p.getPrimaryCommunalPlace().checkVisit(p, hour, day, lockdown);
+                if (visit) {
+                    left.add(p);
+                }
+            }
+        }
+        people.removeAll(left);
+        vPeople.removeAll(left);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -12,6 +12,7 @@ import org.apache.commons.math3.random.RandomDataGenerator;
 import uk.co.ramp.covid.simulation.RunModel;
 import uk.co.ramp.covid.simulation.population.CStatus;
 import uk.co.ramp.covid.simulation.population.Person;
+import uk.co.ramp.covid.simulation.population.PopulationParameters;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.util.*;
@@ -129,7 +130,7 @@ public class Household extends Place {
         ArrayList<Person> left = new ArrayList<>();
 
         for (Person p : vVisitors) {
-            if (rng.nextUniform(0, 1) < 0.5) { // Assumes a 50% probability that people will go home each hour
+            if (rng.nextUniform(0, 1) < PopulationParameters.get().getHouseholdVisitorLeaveRate()) {
                 left.add(p);
                 if (p.cStatus() != CStatus.DEAD) {
                    p.returnHome();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
@@ -4,8 +4,7 @@ import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 public class Nursery extends CommunalPlace {
-    public Nursery(int cindex) {
-        super(cindex);
+    public Nursery() {
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpNurseryTrans();
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -4,8 +4,7 @@ import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 public class Office extends CommunalPlace {
-    public Office(int cindex) {
-        super(cindex);
+    public Office() {
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpOfficeTrans();
         keyProb = PopulationParameters.get().getpOfficeKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -1,0 +1,64 @@
+package uk.co.ramp.covid.simulation.place;
+
+import uk.co.ramp.covid.simulation.DailyStats;
+import uk.co.ramp.covid.simulation.population.CStatus;
+import uk.co.ramp.covid.simulation.population.Person;
+import uk.co.ramp.covid.simulation.population.PopulationParameters;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public abstract class Place {
+
+    protected List<Person> people;
+    protected double sDistance;
+    protected double transProb;
+
+    abstract public void reportInfection(DailyStats s);
+
+    public Place() {
+        this.people = new ArrayList<>();
+        this.transProb = PopulationParameters.get().getpBaseTrans();
+        this.sDistance = 1.0;
+    }
+
+    public List<Person> getPeople() {
+        return people;
+    }
+
+    private void registerInfection(DailyStats s, Person p) {
+        reportInfection(s);
+        p.reportInfection(s);
+    }
+
+    protected void doInfect(DailyStats stats) {
+        List<Person> deaths = new ArrayList<>();
+        for (Person cPers : people) {
+            if (cPers.getInfectionStatus() && !cPers.isRecovered()) {
+                cPers.stepInfection();
+                if (cPers.isInfectious()) {
+                    for (Person nPers : people) {
+                        if (cPers != nPers) {
+                            if (!nPers.getInfectionStatus()) {
+                                boolean infected = nPers.infChallenge(this.transProb * this.sDistance);
+                                if (infected) {
+                                    registerInfection(stats, nPers);
+                                }
+                            }
+                        }
+                    }
+                }
+                if (cPers.cStatus() == CStatus.DEAD) {
+                    cPers.reportDeath(stats);
+                    deaths.add(cPers);
+                }
+                if (cPers.cStatus() == CStatus.RECOVERED) {
+                    cPers.setRecovered(true);
+                }
+            }
+        }
+        people.removeAll(deaths);
+    }
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Places.java
@@ -1,0 +1,178 @@
+package uk.co.ramp.covid.simulation.place;
+
+import uk.co.ramp.covid.simulation.util.RNG;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Helper class to manage communal places of particular types */
+public class Places {
+
+    private List<Office> offices;
+    private List<ConstructionSite> constructionSites;
+    private List<Hospital> hospitals;
+    private List<Nursery> nurseries;
+    private List<Restaurant> restaurants;
+    private List<School> schools;
+    private List<Shop> shops;
+
+    public List<Office> getOffices() {
+        return offices;
+    }
+
+    public List<ConstructionSite> getConstructionSites() {
+        return constructionSites;
+    }
+
+    public List<Hospital> getHospitals() {
+        return hospitals;
+    }
+
+    public List<Nursery> getNurseries() {
+        return nurseries;
+    }
+
+    public List<Restaurant> getRestaurants() {
+        return restaurants;
+    }
+
+    public List<School> getSchools() {
+        return schools;
+    }
+
+    public List<Shop> getShops() {
+        return shops;
+    }
+
+    public List<CommunalPlace> getAll() {
+        return all;
+    }
+
+    private List<CommunalPlace> all;
+
+    public Places() {
+        offices = new ArrayList<>();
+        constructionSites = new ArrayList<>();
+        hospitals = new ArrayList<>();
+        nurseries = new ArrayList<>();
+        restaurants = new ArrayList<>();
+        schools = new ArrayList<>();
+        shops = new ArrayList<>();
+        all = new ArrayList<>();
+    }
+
+    public void addOffice(Office o) {
+        offices.add(o);
+        all.add(o);
+    }
+
+    public void addConstructionSite(ConstructionSite s) {
+        constructionSites.add(s);
+        all.add(s);
+    }
+
+    public void addHospital(Hospital h) {
+        hospitals.add(h);
+        all.add(h);
+    }
+
+    public void addNursery(Nursery n) {
+        nurseries.add(n);
+        all.add(n);
+    }
+
+    public void addRestaurant(Restaurant r) {
+        restaurants.add(r);
+        all.add(r);
+    }
+
+    public void addSchool(School s) {
+        schools.add(s);
+        all.add(s);
+    }
+
+    public void addShop(Shop s) {
+        shops.add(s);
+        all.add(s);
+    }
+
+    // We often need a random place
+    private <T> T getRandom(List<T> s) {
+        int i = (int) RNG.get().nextInt(0, s.size() - 1);
+        return s.get(i);
+    }
+
+    public Office getRandomOffice() {
+        return getRandom(offices);
+    }
+
+    public ConstructionSite getRandomConstructionSite() {
+        return getRandom(constructionSites);
+    }
+
+    public Hospital getRandomHospital() {
+        return getRandom(hospitals);
+    }
+
+    public Nursery getRandomNursery() {
+        return getRandom(nurseries);
+    }
+
+    public Restaurant getRandomRestaurant() {
+        return getRandom(restaurants);
+    }
+
+    public School getRandomSchool() {
+        return getRandom(schools);
+    }
+
+    public Shop getRandomShop() {
+        return getRandom(shops);
+    }
+    
+    public void createNOffices(int n) {
+        for (int i = 0; i < n; i++) {
+            addOffice(new Office());
+        }
+    }
+
+    public void createNHospitals(int n) {
+        for (int i = 0; i < n; i++) {
+            addHospital(new Hospital());
+        }
+    }
+
+    public void createNSchools(int n) {
+        for (int i = 0; i < n; i++) {
+            addSchool(new School());
+        }
+    }
+    public void createNNurseries(int n) {
+        for (int i = 0; i < n; i++) {
+            addNursery(new Nursery());
+        }
+    }
+
+    public void createNRestaurants(int n) {
+        for (int i = 0; i < n; i++) {
+            addRestaurant(new Restaurant());
+        }
+    }
+
+    public void createNShops(int n) {
+        for (int i = 0; i < n; i++) {
+            addShop(new Shop());
+        }
+    }
+
+    public void createNConstructionSites(int n) {
+        for (int i = 0; i < n; i++) {
+            addConstructionSite(new ConstructionSite());
+        }
+    }
+
+    public List<CommunalPlace> getAllPlaces() {
+        return this.all;
+    }
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -17,20 +17,20 @@ public class Restaurant extends CommunalPlace {
     }
 
     public void shoppingTrip(ArrayList<Person> vHouse) {
-        this.listPeople.addAll(vHouse);
+        people.addAll(vHouse);
     }
 
-    public ArrayList<Person> sendHome(int hour) {
-        ArrayList<Person> vReturn = new ArrayList<>();
-        for (int i = 0; i < this.listPeople.size(); i++) {
-            Person nPers = this.listPeople.get(i);
-            if (!nPers.isShopWorker() && rng.nextUniform(0, 1) < 0.4 || hour < super.endTime) {// Assumes a median lenght of shopping trip of 2 hours
-                vReturn.add(nPers);
-                this.listPeople.remove(i);
-                i--;
+    public int sendHome(int hour) {
+        ArrayList<Person> left = new ArrayList<>();
+        for (Person nPers : people) {
+            if (!nPers.isShopWorker() && rng.nextUniform(0, 1) < 0.4
+                    || hour < super.endTime) { // Assumes a median lenght of shopping trip of 2 hours
+                left.add(nPers);
+                nPers.returnHome();
             }
         }
-        return vReturn;
+        people.removeAll(left);
+        return left.size();
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -7,8 +7,7 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 import java.util.ArrayList;
 
 public class Restaurant extends CommunalPlace {
-    public Restaurant(int cindex) {
-        super(cindex);
+    public Restaurant() {
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpRestaurantTrans();
         startDay = 1;
         endDay = 7;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -4,8 +4,7 @@ import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 public class School extends CommunalPlace {
-    public School(int cindex) {
-        super(cindex);
+    public School() {
         int startTime = 9; // TODO. Not used at the moment, but may be used in the future. LEave them in for completeness
         int endTime = 15;
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpSchoolTrans();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -7,8 +7,7 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 import java.util.ArrayList;
 
 public class Shop extends CommunalPlace {
-    public Shop(int cindex) {
-        super(cindex);
+    public Shop() {
         transProb = PopulationParameters.get().getpBaseTrans() *  PopulationParameters.get().getpShopTrans();
         startDay = 1;
         endDay = 7;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -17,20 +17,20 @@ public class Shop extends CommunalPlace {
     }
 
     public void shoppingTrip(ArrayList<Person> vHouse) {
-        this.listPeople.addAll(vHouse);
+       people.addAll(vHouse);
     }
 
-    public ArrayList<Person> sendHome(int hour) {
-        ArrayList<Person> vReturn = new ArrayList<>();
-        for (int i = 0; i < this.listPeople.size(); i++) {
-            Person nPers = this.listPeople.get(i);
-            if (!nPers.isShopWorker() && rng.nextUniform(0, 1) < 0.5 || hour < super.endTime) {// Assumes a median lenght of shopping trip of 2 hours
-                vReturn.add(nPers);
-                this.listPeople.remove(i);
-                i--;
+    public int sendHome(int hour) {
+        ArrayList<Person> left = new ArrayList<>();
+        for (Person nPers : people) {
+            if (!nPers.isShopWorker() && rng.nextUniform(0, 1) < 0.5 
+                    || hour < super.endTime) {// Assumes a median lenght of shopping trip of 2 hours
+                left.add(nPers);
+                nPers.returnHome();
             }
         }
-        return vReturn;
+        people.removeAll(left);
+        return left.size();
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
@@ -2,7 +2,6 @@ package uk.co.ramp.covid.simulation.population;
 
 import uk.co.ramp.covid.simulation.CovidParameters;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.util.ProbabilityDistribution;
 
 public class Adult extends Person {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
@@ -46,37 +46,25 @@ public class Adult extends Person {
     }
 
     @Override
-    public void allocateCommunalPlace(Population p) {
+    public void allocateCommunalPlace(Places p) {
         switch(profession) {
             case TEACHER: {
-                CommunalPlace property = p.getRandomPlace();
-                while (!(property instanceof School)) property = p.getRandomPlace();
-                setPrimaryPlace(property);
+                setPrimaryPlace(p.getRandomSchool());
             } break;
             case SHOP: {
-                CommunalPlace property = p.getRandomPlace();
-                while (!(property instanceof Shop)) property = p.getRandomPlace();
-                setPrimaryPlace(property);
+                setPrimaryPlace(p.getRandomShop());
             } break;
             case CONSTRUCTION: {
-                CommunalPlace property = p.getRandomPlace();
-                while (!(property instanceof ConstructionSite)) property = p.getRandomPlace();
-                setPrimaryPlace(property);
+                setPrimaryPlace(p.getRandomConstructionSite());
             } break;
             case OFFICE: {
-                CommunalPlace property = p.getRandomPlace();
-                while (!(property instanceof Office)) property = p.getRandomPlace();
-                setPrimaryPlace(property);
+                setPrimaryPlace(p.getRandomOffice());
             } break;
             case HOSPITAL: {
-                CommunalPlace property = p.getRandomPlace();
-                while (!(property instanceof Hospital)) property = p.getRandomPlace();
-                setPrimaryPlace(property);
+                setPrimaryPlace(p.getRandomHospital());
             } break;
             case RESTAURANT: {
-                CommunalPlace property = p.getRandomPlace();
-                while (!(property instanceof Restaurant)) property = p.getRandomPlace();
-                setPrimaryPlace(property);
+                setPrimaryPlace(p.getRandomRestaurant());
             } break;
         }
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Child.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Child.java
@@ -3,6 +3,7 @@ package uk.co.ramp.covid.simulation.population;
 import uk.co.ramp.covid.simulation.CovidParameters;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.place.CommunalPlace;
+import uk.co.ramp.covid.simulation.place.Places;
 import uk.co.ramp.covid.simulation.place.School;
 
 public class Child extends Person {
@@ -21,10 +22,8 @@ public class Child extends Person {
 
     // All children go to school
     @Override
-    public void allocateCommunalPlace(Population p) {
-        CommunalPlace property = p.getRandomPlace();
-        while (!(property instanceof School)) property = p.getRandomPlace();
-        setPrimaryPlace(property);
+    public void allocateCommunalPlace(Places p) {
+        setPrimaryPlace(p.getRandomSchool());
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Child.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Child.java
@@ -2,9 +2,6 @@ package uk.co.ramp.covid.simulation.population;
 
 import uk.co.ramp.covid.simulation.CovidParameters;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.place.CommunalPlace;
-import uk.co.ramp.covid.simulation.place.Places;
-import uk.co.ramp.covid.simulation.place.School;
 
 public class Child extends Person {
 

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Infant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Infant.java
@@ -2,9 +2,6 @@ package uk.co.ramp.covid.simulation.population;
 
 import uk.co.ramp.covid.simulation.CovidParameters;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.place.CommunalPlace;
-import uk.co.ramp.covid.simulation.place.Nursery;
-import uk.co.ramp.covid.simulation.place.Places;
 
 public class Infant extends Person {
 

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Infant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Infant.java
@@ -4,6 +4,7 @@ import uk.co.ramp.covid.simulation.CovidParameters;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.place.CommunalPlace;
 import uk.co.ramp.covid.simulation.place.Nursery;
+import uk.co.ramp.covid.simulation.place.Places;
 
 public class Infant extends Person {
 
@@ -32,10 +33,11 @@ public class Infant extends Person {
     }
 
     @Override
-    public void allocateCommunalPlace(Population p) {
-        CommunalPlace property = p.getRandomPlace();
-        while (!(property instanceof Nursery)) property = p.getRandomPlace();
-        setPrimaryPlace(property);
+    public void allocateCommunalPlace(Places p) {
+        if (goesToNursery) {
+            setPrimaryPlace(p.getRandomNursery());
+        }
+
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Pensioner.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Pensioner.java
@@ -2,7 +2,6 @@ package uk.co.ramp.covid.simulation.population;
 
 import uk.co.ramp.covid.simulation.CovidParameters;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.place.Places;
 
 public class Pensioner extends Person {
 

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Pensioner.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Pensioner.java
@@ -2,6 +2,7 @@ package uk.co.ramp.covid.simulation.population;
 
 import uk.co.ramp.covid.simulation.CovidParameters;
 import uk.co.ramp.covid.simulation.DailyStats;
+import uk.co.ramp.covid.simulation.place.Places;
 
 public class Pensioner extends Person {
 
@@ -16,7 +17,7 @@ public class Pensioner extends Person {
     }
 
     @Override
-    public void allocateCommunalPlace(Population p) {}
+    public void allocateCommunalPlace(Places p) {}
 
     @Override
     public boolean avoidsPhase2(double testP) {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -9,7 +9,6 @@ import uk.co.ramp.covid.simulation.Covid;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.place.CommunalPlace;
 import uk.co.ramp.covid.simulation.place.Household;
-import uk.co.ramp.covid.simulation.place.Places;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 public abstract class Person {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -126,6 +126,12 @@ public abstract class Person {
         return cStatus;
     }
 
+    public boolean isInfectious() {
+        return cStatus() == CStatus.ASYMPTOMATIC
+                || cStatus() == CStatus.PHASE1
+                || cStatus() == CStatus.PHASE2;
+    }
+
     public boolean hasPrimaryCommunalPlace() {
         return primaryPlace != null;
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -9,6 +9,7 @@ import uk.co.ramp.covid.simulation.Covid;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.place.CommunalPlace;
 import uk.co.ramp.covid.simulation.place.Household;
+import uk.co.ramp.covid.simulation.place.Places;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 public abstract class Person {
@@ -25,7 +26,7 @@ public abstract class Person {
     
     public abstract void reportInfection(DailyStats s);
     public abstract void reportDeath (DailyStats s);
-    public abstract void allocateCommunalPlace(Population p);
+    public abstract void allocateCommunalPlace(Places p);
 
     public Person() {
         this.rng = RNG.get();

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
@@ -1,5 +1,6 @@
-package uk.co.ramp.covid.simulation.place;
+package uk.co.ramp.covid.simulation.population;
 
+import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.util.ArrayList;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
@@ -100,8 +100,11 @@ public class Places {
 
     // We often need a random place
     private <T> T getRandom(List<T> s) {
-        int i = (int) RNG.get().nextInt(0, s.size() - 1);
-        return s.get(i);
+        if (s.size() > 0) {
+            int i = (int) RNG.get().nextInt(0, s.size() - 1);
+            return s.get(i);
+        }
+        return null;
     }
 
     public Office getRandomOffice() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -457,18 +457,6 @@ public class Population {
         return aPopulation;
     }
 
-    public CommunalPlace[] getcPlaces() {
-        return cPlaces;
-    }
-
-    public int[] getShopIndexes() {
-        return shopIndexes;
-    }
-
-    public int[] getRestaurantIndexes() {
-        return restaurantIndexes;
-    }
-
     public boolean isLockdown() {
         return lockdown;
     }
@@ -491,5 +479,9 @@ public class Population {
 
     public boolean isSchoolL() {
         return schoolL;
+    }
+
+    public Places getPlaces() {
+        return places;
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -25,9 +25,7 @@ public class Population {
     private final int nHousehold;
     private final Household[] population;
     private final Person[] aPopulation;
-    private CommunalPlace[] cPlaces;
-    private int[] shopIndexes;
-    private int[] restaurantIndexes;
+    private Places places;
     private boolean lockdown;
     private boolean rLockdown;
     private int lockdownStart;
@@ -44,6 +42,7 @@ public class Population {
 
         this.population = new Household[this.nHousehold];
         this.aPopulation = new Person[this.populationSize];
+        this.places = new Places();
         this.lockdownStart = (-1);
         this.lockdownEnd = (-1);
         this.socialDist = 1.0;
@@ -224,31 +223,16 @@ public class Population {
         int nConstructionSites = populationSize / PopulationParameters.get().getConstructionSiteRatio();
         int nNurseries = populationSize / PopulationParameters.get().getNurseriesRatio();
         int nRestaurants = populationSize / PopulationParameters.get().getRestaurantRatio();
-        int nEstablishments = nHospitals + nSchools + nShops + nOffices + nConstructionSites + nNurseries + nRestaurants;
-        this.shopIndexes = new int[nShops];
-        this.restaurantIndexes = new int[nRestaurants];
 
-        LOGGER.info("Total number of establishments = {}", nEstablishments);
+        places.createNHospitals(nHospitals);
+        places.createNSchools(nSchools);
+        places.createNShops(nShops);
+        places.createNOffices(nOffices);
+        places.createNConstructionSites(nConstructionSites);
+        places.createNNurseries(nNurseries);
+        places.createNRestaurants(nRestaurants);
 
-        CommunalPlace[] places = new CommunalPlace[nEstablishments];
-        for (int i = 0; i < nEstablishments; i++) {
-            if (i < nHospitals) places[i] = new Hospital(i);
-            else if (i < nHospitals + nSchools) places[i] = new School(i);
-            else if (i < nHospitals + nSchools + nShops) { // Allocate shops and their indexes
-                places[i] = new Shop(i);
-                this.shopIndexes[i - nHospitals - nSchools] = i;
-            } else if (i < nHospitals + nSchools + nShops + nOffices) places[i] = new Office(i);
-            else if (i < nHospitals + nSchools + nShops + nOffices + nConstructionSites)
-                places[i] = new ConstructionSite(i);
-            else if (i < nHospitals + nSchools + nShops + nOffices + nConstructionSites + nNurseries)
-                places[i] = new Nursery(i);
-            else if (i < nHospitals + nSchools + nShops + nOffices + nConstructionSites + nNurseries + nRestaurants) {
-                places[i] = new Restaurant(i);
-                this.restaurantIndexes[i - nHospitals - nSchools - nShops - nOffices - nConstructionSites - nNurseries] = i;
-            }
-
-        }
-        this.cPlaces = places;
+        LOGGER.info("Total number of establishments = {}", places.getAllPlaces().size());
     }
 
     // Allocates people to communal places - work environments
@@ -256,16 +240,10 @@ public class Population {
         for (int i = 0; i < this.nHousehold; i++) {
             for (int j = 0; j < this.population[i].getHouseholdSize(); j++) {
                 Person cPerson = this.population[i].getPerson(j);
-                cPerson.allocateCommunalPlace(this);
+                cPerson.allocateCommunalPlace(places);
             }
         }
         this.assignNeighbours();
-    }
-
-    // For selecting a CommunalPlace at random to assign a People to
-    public CommunalPlace getRandomPlace() {
-        int rnd = rng.nextInt(0, this.cPlaces.length - 1);
-        return this.cPlaces[rnd];
     }
 
     // This method assigns a random number of neighbours to each Household
@@ -352,7 +330,7 @@ public class Population {
 
     // Sets the social distancing to parameters wihtin the CommunalPlaces
     private void socialDistancing() {
-        for (CommunalPlace cPlace : this.cPlaces) {
+        for (CommunalPlace cPlace : places.getAllPlaces()) {
             cPlace.adjustSDist(this.socialDist);
         }
     }
@@ -400,16 +378,17 @@ public class Population {
 
     // This sets the schools exempt from lockdown if that is triggered. Somewhat fudged at present by setting the schools to be KeyPremises - not entirely what thta was intended for, but it works
     private void schoolExemption() {
-        for (CommunalPlace cPlace : this.cPlaces) {
-            if (cPlace instanceof School || cPlace instanceof Nursery) {
-                cPlace.overrideKeyPremises(true);
-            }
+        for (School s : places.getSchools()) {
+                s.overrideKeyPremises(true);
+        }
+        for (Nursery n : places.getNurseries()) {
+            n.overrideKeyPremises(true);
         }
     }
 
     // People returning ome at the end of the day
     private void cyclePlaces(int hour, DailyStats stats) {
-        for (CommunalPlace cPlace : this.cPlaces) {
+        for (CommunalPlace cPlace : places.getAllPlaces()) {
             ArrayList<Person> retPeople = cPlace.cyclePlace(hour, stats);
             for (Person cPers : retPeople) {
                 cPers.returnHome();
@@ -458,8 +437,8 @@ public class Population {
                     vNext = household.shoppingTrip();
                 }
                 if (vNext != null) {
-                    int shopSample = rng.nextInt(0,this.shopIndexes.length - 1);
-                    ((Shop) this.cPlaces[this.shopIndexes[shopSample]]).shoppingTrip(vNext);
+                    Shop s = places.getRandomShop();
+                    s.shoppingTrip(vNext);
                 }
                 vNext = null;
             }
@@ -468,8 +447,8 @@ public class Population {
 
     // People return from shopping
     private void returnShoppers(int hour) {
-        for (int shopIndex : this.shopIndexes) {
-            ArrayList<Person> vCurr = ((Shop) this.cPlaces[shopIndex]).sendHome(hour);
+        for (Shop s  : places.getShops()) {
+            ArrayList<Person> vCurr = s.sendHome(hour);
             if (vCurr != null) {
                 for (Person nPers : vCurr) {
                     nPers.returnHome();
@@ -486,27 +465,25 @@ public class Population {
         int endDay = 7;
         double visitFrequency = 2.0 / 7.0; // Based on three visits per week to shops
         double visitProb = visitFrequency / 12.0;
-        ArrayList<Person> vNext = null;
 
         if (hour >= openingTime && hour < closingTime && startDay >= day && endDay <= day) {
             for (Household household : this.population) {
+                ArrayList<Person> vNext = null;
                 if (rng.nextUniform(0, 1) < visitProb) {
                     vNext = household.shoppingTrip(); // This method is fine for our purposes here
                 }
                 if (vNext != null) {
-                    int shopSample = rng.nextInt(0, this.restaurantIndexes.length - 1);
-                    ((Restaurant) this.cPlaces[this.restaurantIndexes[shopSample]]).shoppingTrip(vNext);
+                    Restaurant r = places.getRandomRestaurant();
+                    r.shoppingTrip(vNext);
                 }
-                vNext = null;
             }
         }
     }
 
     // People return from dinner
     private void returnRestaurant(int hour) {
-        // TODO CHECK-ME: Should this be restaurantIndexes?
-        for (int shopIndex : this.shopIndexes) {
-            ArrayList<Person> vCurr = ((Shop) this.cPlaces[shopIndex]).sendHome(hour);
+        for (Restaurant r : places.getRestaurants()) {
+            ArrayList<Person> vCurr = r.sendHome(hour);
             if (vCurr != null) {
                 for (Person nPers : vCurr) {
                    nPers.returnHome();

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -10,7 +10,6 @@ import org.apache.commons.math3.random.RandomDataGenerator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.RunModel;
 import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.util.ProbabilityDistribution;
 import uk.co.ramp.covid.simulation.util.RNG;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -337,14 +337,8 @@ public class Population {
 
     // This method generates output at the end of each day
     private DailyStats processCases(DailyStats stats) {
-        for (Household cHouse : population) {
-            for (Person p : cHouse.getInhabitants()) {
-                stats.processPerson(p);
-            }
-            for (Person p: cHouse.getVisitors()) {
-               stats.processPerson(p);
-            }
-            stats.incrementDeaths(cHouse.getDeaths());
+        for (Person p : aPopulation) {
+            stats.processPerson(p);
         }
         stats.log();
         return stats;
@@ -388,12 +382,7 @@ public class Population {
 
     // People returning ome at the end of the day
     private void cyclePlaces(int hour, DailyStats stats) {
-        for (CommunalPlace cPlace : places.getAllPlaces()) {
-            ArrayList<Person> retPeople = cPlace.cyclePlace(hour, stats);
-            for (Person cPers : retPeople) {
-                cPers.returnHome();
-            }
-        }
+        places.getAllPlaces().forEach(p -> p.cyclePlace(hour,stats));
     }
 
     // Go through neighbours and see if they visit anybody

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -345,28 +345,14 @@ public class Population {
     // Step through the households to identify individual movements to CommunalPlaces
     private void cycleHouseholds(int day, int hour, DailyStats stats) {
         for (Household household : this.population) {
-            ArrayList<Person> vHouse = household.cycleHouse(stats);
-            this.cycleMovements(vHouse, day, hour);
+            household.cycleHouse(stats);
+            household.cycleMovements(day, hour, lockdown);
             household.sendNeighboursHome();
             if (!this.lockdown) this.cycleNeighbours(household);
         }
     }
 
-    // For each household processes any movements to Communal Places that are relevant
-    private void cycleMovements(ArrayList<Person> vHouse, int day, int hour) {
-        int i = 0;
-        while (i < vHouse.size()) {
-            Person nPers = vHouse.get(i);
-            if (nPers.hasPrimaryCommunalPlace() && !nPers.getQuarantine()) {
-                boolean visit = nPers.getPrimaryCommunalPlace().checkVisit(nPers, hour, day, this.lockdown);
-                if (visit) {
-                    vHouse.remove(i);
-                    i--;
-                }
-            }
-            i++;
-        }
-    }
+
 
     // This sets the schools exempt from lockdown if that is triggered. Somewhat fudged at present by setting the schools to be KeyPremises - not entirely what thta was intended for, but it works
     private void schoolExemption() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
@@ -2,6 +2,7 @@ package uk.co.ramp.covid.simulation.population;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.co.ramp.covid.simulation.place.Household;
 
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -172,19 +173,6 @@ public class PopulationParameters {
         }
     }
 
-    private static class NeighbourProperties {
-        public Double neighbourVisitFreq = null;
-        public Integer expectedNeighbours = null;
-
-        @Override
-        public String toString() {
-            return "NeighbourProperties{" +
-                    "neighbourVisitFreq=" + neighbourVisitFreq +
-                    ", expectedNeighbours=" + expectedNeighbours +
-                    '}';
-        }
-    }
-
     private static class PersonProperties {
         public Double pQuarantine = null;
         public Double pTransmission = null;
@@ -197,6 +185,21 @@ public class PopulationParameters {
                     '}';
         }
     }
+    
+    private static class HouseholdProperties {
+        public Double visitorLeaveRate = null;
+        public Double neighbourVisitFreq = null;
+        public Integer expectedNeighbours = null;
+
+        @Override
+        public String toString() {
+            return "HouseholdProperties{" +
+                    "visitorLeaveRate=" + visitorLeaveRate +
+                    ", neighbourVisitFreq=" + neighbourVisitFreq +
+                    ", expectedNeighbours=" + expectedNeighbours +
+                    '}';
+        }
+    }
 
     private final Population population;
     private final Households households;
@@ -205,8 +208,8 @@ public class PopulationParameters {
     private final WorkerAllocation workerAllocation;
     private final BuildingProperties buildingProperties;
     private final InfantAllocation infantAllocation;
-    private final NeighbourProperties neighbourProperties;
     private final PersonProperties personProperties;
+    private final HouseholdProperties householdProperties;
 
     private PopulationParameters() {
         population = new Population();
@@ -216,14 +219,15 @@ public class PopulationParameters {
         workerAllocation = new WorkerAllocation();
         buildingProperties = new BuildingProperties();
         infantAllocation = new InfantAllocation();
-        neighbourProperties = new NeighbourProperties();
         personProperties = new PersonProperties();
+        householdProperties = new HouseholdProperties();
     }
 
     public boolean isValid() {
         ParameterInitialisedChecker checker = new ParameterInitialisedChecker();
         boolean valid = true;
-        // We don't do this in a single statement to ensure that all the "uninitalised" parameter warnings are printed in one go instead of being short circuited
+        // We don't do this in a single statement to ensure that all the "uninitalised" parameter warnings are printed
+        // in one go instead of being short circuited
         valid = valid && checker.isValid(population);
         valid = valid && checker.isValid(households);
         valid = valid && checker.isValid(additionalMembersDistributions);
@@ -231,8 +235,8 @@ public class PopulationParameters {
         valid = valid && checker.isValid(workerAllocation);
         valid = valid && checker.isValid(buildingProperties);
         valid = valid && checker.isValid(infantAllocation);
-        valid = valid && checker.isValid(neighbourProperties);
         valid = valid && checker.isValid(personProperties);
+        valid = valid && checker.isValid(householdProperties);
         return valid;
     }
 
@@ -418,13 +422,14 @@ public class PopulationParameters {
         return infantAllocation.pAttendsNursery;
     }
 
-    // Neighbour properties
+    // Household properties
     public double getNeighbourVisitFreq() {
-        return neighbourProperties.neighbourVisitFreq;
+        return householdProperties.neighbourVisitFreq;
     }
     public int getExpectedNeighbours() {
-        return neighbourProperties.expectedNeighbours;
+        return householdProperties.expectedNeighbours;
     }
+    public double getHouseholdVisitorLeaveRate() { return householdProperties.visitorLeaveRate; }
 
     // Person Properties
     public double getpQuarantine() {
@@ -434,6 +439,7 @@ public class PopulationParameters {
     public double getpTransmission() {
         return personProperties.pTransmission;
     }
+
 
     @Override
     public String toString() {
@@ -445,7 +451,7 @@ public class PopulationParameters {
                 workerAllocation + "\n" +
                 buildingProperties + "\n" +
                 infantAllocation + "\n" +
-                neighbourProperties + "\n" +
+                householdProperties + "\n" +
                 personProperties + "\n" +
                 '}';
     }

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -57,7 +57,9 @@ public class ModelTest {
         for (DailyStats s : stats.get(0)) {
             cummulativeI = s.getTotalInfected() + s.getRecovered() + s.getDead();
             totalDailyInfects += s.getTotalDailyInfections();
+            assertEquals(s.getHealthy(), population - cummulativeI);
         }
+
         assertEquals(cummulativeI, totalDailyInfects);
 
         // Deaths should be proportional to phase2 progression

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -39,7 +39,13 @@ public class ModelTest {
         int lastTotalInfected = 10;
         for (DailyStats s : stats.get(0)) {
             assertEquals(10000, s.getTotalPopulation());
-            assertTrue(s.getDead() <= s.getRecovered() * 0.1);
+
+            // Check there are deaths, but not too many
+            // Near the start of runs this is sometimes untrue, e.g. we may have 8 recoveries and 1 death,
+            // so we wait for enough recoveries for this to make sense.
+            if (s.getRecovered() >= 10) {
+                assertTrue(s.getDead() <= s.getRecovered() * 0.1);
+            }
             assertTrue(s.getDead() + nInfections >= s.getRecovered() * 0.005);
             assertTrue(s.getTotalInfected() <= lastTotalInfected * 2);
             lastTotalInfected = s.getTotalInfected();

--- a/src/test/java/uk/co/ramp/covid/simulation/io/ParameterReaderTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/io/ParameterReaderTest.java
@@ -86,6 +86,8 @@ public class ParameterReaderTest {
 
         assertEquals(0.9, PopulationParameters.get().getpTransmission(), EPSILON);
         assertEquals(0.7, PopulationParameters.get().getpQuarantine(), EPSILON);
+
+        assertEquals(0.8, PopulationParameters.get().getHouseholdVisitorLeaveRate(), EPSILON);
     }
 
     @After

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
@@ -24,7 +24,7 @@ public class ConstructionSiteTest {
     @Test
     public void testConstructionSiteTransProb() throws JsonParseException, IOException {
         RNG.seed(123);
-        ConstructionSite constructionSite = new ConstructionSite(0);
+        ConstructionSite constructionSite = new ConstructionSite();
         double expProb = PopulationParameters.get().getpBaseTrans() * 10d / (5000d / 100d);
         double delta = 0.01;
         assertEquals("Unexpected construction site TransProb", expProb, constructionSite.transProb, delta);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -24,7 +24,7 @@ public class HospitalTest {
     @Test
     public void testHospitalTransProb() throws JsonParseException, IOException {
         RNG.seed(123);
-        Hospital hospital = new Hospital(0);
+        Hospital hospital = new Hospital();
         double expProb = PopulationParameters.get().getpBaseTrans() * 15d / (5000d / 10d);
         double delta = 0.01;
         assertEquals("Unexpected hospital TransProb", expProb, hospital.transProb, delta);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -94,30 +94,10 @@ public class HouseholdTest {
     }
 
     @Test
-    public void testCombVectors() {
-        Household newHouse = new Household(Household.HouseholdType.ADULT);
-        Person p4 = new Adult();
-        newHouse.addPerson(p4);
-        household.welcomeNeighbours(newHouse);
-        int expSize = 4;
-        assertEquals("Unexpected combined list size", expSize, household.combVectors().size());
-    }
-
-    @Test
     public void testCycleHouse() {
         int expSize = 3;
         DailyStats s = new DailyStats(0);
         assertEquals("Unexpected household size", expSize, household.cycleHouse(s).size());
-    }
-
-    @Test
-    public void testGetDeaths() {
-        Person p1 = new Adult();
-        Person p2 = new Adult();
-        household.addDeath(p1);
-        household.addDeath(p2);
-        int expDeaths = 2;
-        assertEquals("Unexpected number of deaths", expDeaths, household.getDeaths());
     }
 
     @Test
@@ -138,9 +118,10 @@ public class HouseholdTest {
         Household newHouse = new Household(Household.HouseholdType.ADULT);
         Person p1 = new Adult();
         newHouse.addPerson(p1);
+        p1.setHome(newHouse);
         household.welcomeNeighbours(newHouse);
         int expSize = 1;
-        assertEquals("Unexpected number of visitors", expSize, household.sendNeighboursHome().size());
+        assertEquals("Unexpected number of visitors", expSize, household.sendNeighboursHome());
     }
 
     @Test

--- a/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
@@ -24,7 +24,7 @@ public class NurseryTest {
     @Test
     public void testNurseryTransProb() throws JsonParseException, IOException {
         RNG.seed(123);
-        Nursery nursery = new Nursery(0);
+        Nursery nursery = new Nursery();
         double expProb = PopulationParameters.get().getpBaseTrans() * 30d / (34000d / 50d);
         double delta = 0.01;
         assertEquals("Unexpected nursery TransProb", expProb, nursery.transProb, delta);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
@@ -24,7 +24,7 @@ public class OfficeTest {
     @Test
     public void testOfficeTransProb() throws JsonParseException, IOException {
         RNG.seed(123);
-        Office office = new Office(0);
+        Office office = new Office();
         double expProb = PopulationParameters.get().getpBaseTrans() * 10d / (10000d / 400d);
         double delta = 0.01;
         assertEquals("Unexpected office TransProb", expProb, office.transProb, delta);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -30,8 +30,12 @@ public class RestaurantTest {
         restaurant = new Restaurant();
         p1 = new Adult();
         p2 = new Pensioner();
-        restaurant.listPeople.add(p1);
-        restaurant.listPeople.add(p2);
+        Household h1 = new Household(Household.HouseholdType.ADULT);
+        Household h2 = new Household(Household.HouseholdType.PENSIONER);
+        p1.setHome(h1);
+        p2.setHome(h2);
+        restaurant.people.add(p1);
+        restaurant.people.add(p2);
     }
 
     @Test
@@ -47,14 +51,14 @@ public class RestaurantTest {
         personList.add(new Child());
         restaurant.shoppingTrip(personList);
         int expPeople = 3;
-        assertEquals("Unexpected number of people in restaurant", expPeople, restaurant.listPeople.size());
+        assertEquals("Unexpected number of people in restaurant", expPeople, restaurant.people.size());
     }
 
     @Test
     public void testSendHome() {
         int time = restaurant.endTime - 1;
-        ArrayList<Person> personList = restaurant.sendHome(time);
+        int left = restaurant.sendHome(time);
         int expPeople = 2;
-        assertEquals("Unexpected number of people sent home from restaurant", expPeople, personList.size());
+        assertEquals("Unexpected number of people sent home from restaurant", expPeople, left);
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -27,7 +27,7 @@ public class RestaurantTest {
 
         RNG.seed(123);
         //Setup a restaurant with 2 people
-        restaurant = new Restaurant(0);
+        restaurant = new Restaurant();
         p1 = new Adult();
         p2 = new Pensioner();
         restaurant.listPeople.add(p1);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -22,7 +22,7 @@ public class SchoolTest {
     @Test
     public void testSchoolTransProb() {
         RNG.seed(123);
-        School school = new School(0);
+        School school = new School();
         double expProb = PopulationParameters.get().getpBaseTrans() * 30d / (34000d / 50d);
         double delta = 0.01;
         assertEquals("Unexpected school TransProb", expProb, school.transProb, delta);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -29,8 +29,12 @@ public class ShopTest {
         shop = new Shop();
         p1 = new Adult();
         p2 = new Pensioner();
-        shop.listPeople.add(p1);
-        shop.listPeople.add(p2);
+        Household h1 = new Household(Household.HouseholdType.ADULT);
+        Household h2 = new Household(Household.HouseholdType.PENSIONER);
+        p1.setHome(h1);
+        p2.setHome(h2);
+        shop.people.add(p1);
+        shop.people.add(p2);
     }
 
     @Test
@@ -46,14 +50,14 @@ public class ShopTest {
         personList.add(new Child());
         shop.shoppingTrip(personList);
         int expPeople = 3;
-        assertEquals("Unexpected number of people in shop", expPeople, shop.listPeople.size());
+        assertEquals("Unexpected number of people in shop", expPeople, shop.people.size());
     }
 
     @Test
     public void testSendHome() {
         int time = shop.endTime - 1;
-        ArrayList<Person> personList = shop.sendHome(time);
+        int left = shop.sendHome(time);
         int expPeople = 2;
-        assertEquals("Unexpected number of people sent home", expPeople, personList.size());
+        assertEquals("Unexpected number of people sent home", expPeople, left);
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -26,7 +26,7 @@ public class ShopTest {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         RNG.seed(123);
         //Setup a shop with 2 people
-        shop = new Shop(0);
+        shop = new Shop();
         p1 = new Adult();
         p2 = new Pensioner();
         shop.listPeople.add(p1);

--- a/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
@@ -19,7 +19,7 @@ public class ChildTest {
         p.populateHouseholds();
         p.createMixing();
         Child child = new Child();
-        child.allocateCommunalPlace(p);
+        child.allocateCommunalPlace(p.getPlaces());
         assertTrue("Child not at school", child.getPrimaryCommunalPlace() instanceof School);
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -127,7 +127,7 @@ public class PopulationTest {
         Adult adult = new Adult();
         adult.profession = Adult.Professions.CONSTRUCTION;
         p.getPopulation()[0].addPerson(adult);
-        adult.allocateCommunalPlace(p);
+        adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof ConstructionSite);
     }
@@ -139,7 +139,7 @@ public class PopulationTest {
         Adult adult = new Adult();
         adult.profession = Adult.Professions.HOSPITAL;
         p.getPopulation()[0].addPerson(adult);
-        adult.allocateCommunalPlace(p);
+        adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Hospital);
     }
@@ -151,7 +151,7 @@ public class PopulationTest {
         Adult adult = new Adult();
         adult.profession = Adult.Professions.OFFICE;
         p.getPopulation()[0].addPerson(adult);
-        adult.allocateCommunalPlace(p);
+        adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Office);
     }
@@ -163,7 +163,7 @@ public class PopulationTest {
         Adult adult = new Adult();
         adult.profession = Adult.Professions.RESTAURANT;
         p.getPopulation()[0].addPerson(adult);
-        adult.allocateCommunalPlace(p);
+        adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Restaurant);
     }
@@ -175,7 +175,7 @@ public class PopulationTest {
         Adult adult = new Adult();
         adult.profession = Adult.Professions.TEACHER;
         p.getPopulation()[0].addPerson(adult);
-        adult.allocateCommunalPlace(p);
+        adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof School);
     }
@@ -187,7 +187,7 @@ public class PopulationTest {
         Adult adult = new Adult();
         adult.profession = Adult.Professions.SHOP;
         p.getPopulation()[0].addPerson(adult);
-        adult.allocateCommunalPlace(p);
+        adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Shop);
     }

--- a/src/test/resources/default_params.json
+++ b/src/test/resources/default_params.json
@@ -95,7 +95,8 @@
         "infantAllocation":{
             "pAttendsNursery":0.5
         },
-        "neighbourProperties":{
+        "householdProperties":{
+            "visitorLeaveRate":0.5,
             "neighbourVisitFreq":0.006,
             "expectedNeighbours":3
         },

--- a/src/test/resources/test_params.json
+++ b/src/test/resources/test_params.json
@@ -88,8 +88,9 @@
         "infantAllocation":{
             "pAttendsNursery":0.8
         },
-        "neighbourProperties":{
+        "householdProperties":{
             "neighbourVisitFreq":0.05,
+            "visitorLeaveRate":0.8,
             "expectedNeighbours":2
         },
         "personProperties":{


### PR DESCRIPTION
In particular we move infections into a superclass "Place" that allows us to treat all places in a similar manner.

There is a small performance cost to this, for example, we have to manage both the "all people" and "inhabitants/visitor" lists in household; however I think it makes the code much clearer and gives us a single place to make any required changes to infections. Switching to HashSet's might let us improve the performance again and clarify that the order of the people doesn't matter.

Additionally it abstracts the places into a "Places" class that tracks both all places and places by type allowing, for example, getRandomOffice() methods. This provides a hook point for returning offices etc based on a distribution rather than uniformly random (to model things like place sizes).

There remains some room for improvement by unifying the timesteps in future, e.g. by introducing a single "step" methods into "Place" that captures what each place does in an hour.