### PR TITLE
Add an example slurm_submit script

### DIFF
--- a/RunningOnDiRAC.md
+++ b/RunningOnDiRAC.md
@@ -1,0 +1,17 @@
+# Running On DiRAC
+
+Load Java:
+
+    module load jdk-8u141-b15-intel-17.0.4-3g6rhr2
+
+John has downloaded gradle from https://gradle.org/release-nightly/ and unzipped it to `/home/dc-nonw1/gradle`.  To use it:
+
+    export PATH=$PATH:/home/dc-nonw1/gradle/bin
+
+Get the source code from GitHub, and build it with:
+
+    gradle install
+
+Then have a look at the example `slurm_submit` file, which can be run with the command:
+
+    sbatch slurm_submit

--- a/RunningOnDiRAC.md
+++ b/RunningOnDiRAC.md
@@ -1,5 +1,14 @@
 # Running On DiRAC
 
+Follow these instructinos to get an account (for the SCRC Project):
+
+    https://github.com/ScottishCovidResponse/SCRCIssueTracking/wiki/DiRAC-Access
+
+You should receive an email describing how to connect to one of the CSD3 login nodes,
+with something like (replacing your-user-name with your username):
+
+    ssh -l your-user-name login.hpc.cam.ac.uk
+
 Load Java:
 
     module load jdk-8u141-b15-intel-17.0.4-3g6rhr2
@@ -10,8 +19,11 @@ John has downloaded gradle from https://gradle.org/release-nightly/ and unzipped
 
 Get the source code from GitHub, and build it with:
 
+    git clone https://github.com/ScottishCovidResponse/Covid_Simulation_Model.git
+    cd Covid_Simulation_Model
     gradle install
 
-Then have a look at the example `slurm_submit` file, which can be run with the command:
+Then have a look at the "TODO"s in the example `slurm_submit` file, which can be run with the command:
 
     sbatch slurm_submit
+

--- a/combineArrayJobOutputs.sh
+++ b/combineArrayJobOutputs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ $# -le 2 ]
+then
+	echo "Usage: $0 jobID lastArrayIndex"
+	exit 1
+fi
+
+jobID=$1
+lastArrayIndex=$2
+
+# copy first file including header
+cp job_${jobID}_0/example.csv example.csv
+
+# append other files with header stripped
+for ((i = 1 ; i <= $lastArrayIndex ; i++))
+do
+	nextFile="job_${jobID}_${i}/example.csv"
+	tail -n +2 $nextFile >> example.csv
+done
+

--- a/slurm_submit
+++ b/slurm_submit
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+#! sbatch directives begin here ###############################
+#! Name of the job:
+#SBATCH -J cpujob
+#! Which project should be charged:
+#SBATCH -A DIRAC-DC003-CPU
+
+#! Output filename:
+#! %A means slurm job ID and %a means array index
+#SBATCH --output=test_%A_%a.out
+#! Errors filename:
+#SBATCH --error=test_%A_%a.err
+
+#! How many whole nodes should be allocated?
+#SBATCH --nodes=1
+#! How many (MPI) tasks will there be in total? (<= nodes*32)
+#! The skylake/skylake-himem nodes have 32 CPUs (cores) each.
+#SBATCH --ntasks=1
+#! How much wallclock time will be required?
+#SBATCH --time=00:05:00
+#! What types of email messages do you wish to receive?
+#SBATCH --mail-type=FAIL
+#! Uncomment this to prevent the job from being requeued (e.g. if
+#! interrupted by node failure or system downtime):
+##SBATCH --no-requeue
+
+#! Estimated maximum memory needed (job is force-stopped if exceeded):
+#! RAM is allocated in ~5980mb blocks, you are charged per block used,
+#! and unused fractions of blocks will not be usable by others.
+#SBATCH --mem=5980mb
+#! Submit a job array with a range of index values --array=[first]-[last]
+#SBATCH --array=0-1
+
+#! For 6GB per CPU, set "-p skylake"; for 12GB per CPU, set "-p skylake-himem": 
+#SBATCH -p skylake
+
+#! sbatch directives end here (put any additional directives above this line)
+
+#! Note: Charging is determined by core number*walltime.
+
+#! Optionally modify the environment seen by the application
+#! (note that SLURM reproduces the environment at submission irrespective of ~/.bashrc):
+. /etc/profile.d/modules.sh                # Leave this line (enables the module command)
+module purge                               # Removes all modules still loaded
+module load rhel7/default-peta4            # REQUIRED - loads the basic environment
+
+#! Additional module load commands:
+module load jdk-8u141-b15-intel-17.0.4-3g6rhr2
+
+#! The variable $SLURM_ARRAY_TASK_ID contains the array index for each job.
+echo "This is job" $SLURM_ARRAY_TASK_ID
+
+
+#! Work directory (i.e. where the job will run):
+workdir="$SLURM_SUBMIT_DIR/job_$SLURM_ARRAY_TASK_ID"  # The value of SLURM_SUBMIT_DIR sets workdir to the directory
+                             # in which sbatch is run.
+
+mkdir $workdir
+cd $workdir
+
+application="$SLURM_SUBMIT_DIR/build/install/Covid-Simulation-Model/bin/Covid-Simulation-Model"
+paramDir="$SLURM_SUBMIT_DIR/parameters"
+options="$paramDir/example_population_params.json $paramDir/example_model_params.json $SLURM_ARRAY_TASK_ID"
+
+$application $options

--- a/slurm_submit
+++ b/slurm_submit
@@ -2,65 +2,57 @@
 
 #! sbatch directives begin here ###############################
 #! Name of the job:
-#SBATCH -J cpujob
-#! Which project should be charged:
+#SBATCH -J covid-sim-model
+#! Charge the SCRC project:
 #SBATCH -A DIRAC-DC003-CPU
 
-#! Output filename:
+#! Set file paths for output to stdout and stderr:
 #! %A means slurm job ID and %a means array index
-#SBATCH --output=test_%A_%a.out
-#! Errors filename:
-#SBATCH --error=test_%A_%a.err
+#! (Note: It appears that these can _not_ go in the folders we create for each job)
+#SBATCH --output=job_%A_%a_std.out
+#SBATCH --error=job_%A_%a_std.err
 
-#! How many whole nodes should be allocated?
+#! Simple single core jobs use one node and one task
 #SBATCH --nodes=1
-#! How many (MPI) tasks will there be in total? (<= nodes*32)
-#! The skylake/skylake-himem nodes have 32 CPUs (cores) each.
 #SBATCH --ntasks=1
-#! How much wallclock time will be required?
+#! Set a time limit of 5 minutes
 #SBATCH --time=00:05:00
-#! What types of email messages do you wish to receive?
+#! Set --mail-type=FAIL to get an email if the job array fails
 #SBATCH --mail-type=FAIL
-#! Uncomment this to prevent the job from being requeued (e.g. if
-#! interrupted by node failure or system downtime):
-##SBATCH --no-requeue
 
-#! Estimated maximum memory needed (job is force-stopped if exceeded):
-#! RAM is allocated in ~5980mb blocks, you are charged per block used,
-#! and unused fractions of blocks will not be usable by others.
+#! Maximum memory should be 6GB or 12GB
 #SBATCH --mem=5980mb
-#! Submit a job array with a range of index values --array=[first]-[last]
-#SBATCH --array=0-1
-
 #! For 6GB per CPU, set "-p skylake"; for 12GB per CPU, set "-p skylake-himem": 
 #SBATCH -p skylake
 
+#! Note: Charging is determined by core number*walltime (doubled for 12GB per CPU)
+
+#! This submits a job array with a range of index values --array=[first]-[last]
+#! TODO: Set your required number of jobs here
+#SBATCH --array=0-1
+
 #! sbatch directives end here (put any additional directives above this line)
 
-#! Note: Charging is determined by core number*walltime.
-
-#! Optionally modify the environment seen by the application
+#! Setup the environment seen by the application
 #! (note that SLURM reproduces the environment at submission irrespective of ~/.bashrc):
-. /etc/profile.d/modules.sh                # Leave this line (enables the module command)
-module purge                               # Removes all modules still loaded
-module load rhel7/default-peta4            # REQUIRED - loads the basic environment
+. /etc/profile.d/modules.sh                # Enable the module command
+module purge                               # Remove all modules still loaded
+module load rhel7/default-peta4            # Load the basic (required) environment
+module load jdk-8u141-b15-intel-17.0.4-3g6rhr2 # Load Java
 
-#! Additional module load commands:
-module load jdk-8u141-b15-intel-17.0.4-3g6rhr2
+#! Create a folder for each array job
+#! SLURM_SUBMIT_DIR is the directory in which sbatch is run
+#! SLURM_ARRAY_TASK_ID is the array index for each job
+#! SLURM_ARRAY_JOB_ID is the job array's master job ID number
 
-#! The variable $SLURM_ARRAY_TASK_ID contains the array index for each job.
-echo "This is job" $SLURM_ARRAY_TASK_ID
-
-
-#! Work directory (i.e. where the job will run):
-workdir="$SLURM_SUBMIT_DIR/job_$SLURM_ARRAY_TASK_ID"  # The value of SLURM_SUBMIT_DIR sets workdir to the directory
-                             # in which sbatch is run.
-
-mkdir $workdir
+workdir="$SLURM_SUBMIT_DIR/job_${SLURM_ARRAY_JOB_ID}_${SLURM_ARRAY_TASK_ID}"
+mkdir -p $workdir
 cd $workdir
 
+#! TODO: Set these paths to point to the correct model and parameters
 application="$SLURM_SUBMIT_DIR/build/install/Covid-Simulation-Model/bin/Covid-Simulation-Model"
-paramDir="$SLURM_SUBMIT_DIR/parameters"
-options="$paramDir/example_population_params.json $paramDir/example_model_params.json $SLURM_ARRAY_TASK_ID"
+paramsDir="$SLURM_SUBMIT_DIR/parameters"
+populationParams="$paramsDir/example_population_params.json"
+modelParams="$paramsDir/example_model_params.json"
 
-$application $options
+$application $populationParams $modelParams $SLURM_ARRAY_TASK_ID


### PR DESCRIPTION
I have made notes and an example slurm_submit file to make it easier for someone else to run simulations on DiRAC.

There is a remaining issue which I plan to address in a follow-up PR:  The ID of the iterations are currently all zero, so the combined output file doesn't make sense.  (And combining-the-outputs will need documenting.)