### PR TITLE
Add Communal Place Sizes

### DIFF
--- a/parameters/PopulationParameters.md
+++ b/parameters/PopulationParameters.md
@@ -57,15 +57,24 @@ Distribution should add to 1.
 
 -   Object name: `workerAllocation`
 
-| Parameter Name | Description                            | Type   |
-|----------------|----------------------------------------|--------|
-| pOffice        | Probability of working in an office    | Double |
-| pShop          | Probability of working in a shop       | Double |
-| pHospital      | Probability of working in a hospital   | Double |
-| pConstruction  | Probability of working in construction | Double |
-| pTeacher       | Probability of being a teacher         | Double |
-| pRestaurant    | Probability of working in a restaurant | Double |
-| pUnemployed    | Probability of being unemployed        | Double |
+| Parameter Name  | Description                                                             | Type   |
+|-----------------|-------------------------------------------------------------------------|--------|
+| pOffice         | Probability of working in an office                                     | Double |
+| pShop           | Probability of working in a shop                                        | Double |
+| pHospital       | Probability of working in a hospital                                    | Double |
+| pConstruction   | Probability of working in construction                                  | Double |
+| pTeacher        | Probability of being a teacher                                          | Double |
+| pRestaurant     | Probability of working in a restaurant                                  | Double |
+| pUnemployed     | Probability of being unemployed                                         | Double |
+| allocationSizes | Probability of being assigned to work in a large/medium/small workplace | Double |
+
+Where allocationSizes has the form
+
+| Parameter Name | Description                                      | Type   |
+|----------------|--------------------------------------------------|--------|
+| pSmall         | Probability of being assigned a small workplace  | Double |
+| pMed           | Probability of being assigned a medium workplace | Double |
+| pLarge         | Probability of being assigned a large workplace  | Double |
 
 ## Infant Properties
 

--- a/parameters/PopulationParameters.md
+++ b/parameters/PopulationParameters.md
@@ -140,15 +140,31 @@ Determines the number of buildings, of a particular type, per N people.
 
 -   Object name: `buildingDistribution`
 
-| Parameter Name    | Description                     | Type |
-|-------------------|---------------------------------|------|
-| hospitals         | Hospitals per N people          | Int  |
-| schools           | Schools per N people            | Int  |
-| shops             | Shops per N people              | Int  |
-| offices           | Offices per N people            | Int  |
-| constructionSites | Construction Sites per N people | Int  |
-| nurseries         | Nurseries per N people          | Int  |
-| restaurants       | Restaurants per N people        | Int  |
+| Parameter Name        | Description                            | Type |
+|-----------------------|----------------------------------------|------|
+| hospitals             | Hospitals per N people                 | Int  |
+| hospitalSizes         | Distribution of hospital sizes         | Size |
+| schools               | Schools per N people                   | Int  |
+| schoolSizes           | Distribution of school sizes           | Size |
+| shops                 | Shops per N people                     | Int  |
+| shopSizes             | Distribution of shop sizes             | Size |
+| offices               | Offices per N people                   | Int  |
+| officeSizes           | Distribution of office sizes           | Size |
+| constructionSites     | Construction Sites per N people        | Int  |
+| constructionSiteSizes | Distribution of constructionSite sizes | Size |
+| nurseries             | Nurseries per N people                 | Int  |
+| nurserySizes          | Distribution of nursery sizes          | Size |
+| restaurants           | Restaurants per N people               | Int  |
+| restaurantSizes       | Distribution of restaurant sizes       | Size |
+
+Where `Size` is an object with the following parameters:
+
+| Parameter Name | Description                         | Type   |
+|----------------|-------------------------------------|--------|
+| pSmall         | Probability of a place being small  | Double |
+| pMed           | Probability of a place being medium | Double |
+| pLarge         | Probability of a place being large  | Double |
+
 
 ## Building Properties
 

--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -65,6 +65,11 @@
             "schools":2000,
             "shops":500,
             "offices":250,
+            "officeSizes":{
+                "pSmall":0.25,
+                "pMed":0.4,
+                "pLarge":0.35
+            },
             "constructionSites":1000,
             "nurseries":2000,
             "restaurants":1000

--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -62,17 +62,47 @@
         },
         "buildingDistribution":{
             "hospitals":10000,
+            "hospitalSizes":{
+                "pSmall":0,
+                "pMed":1.0,
+                "pLarge":0
+            },
             "schools":2000,
+            "schoolSizes":{
+                "pSmall":0,
+                "pMed":1.0,
+                "pLarge":0
+            },
             "shops":500,
+            "shopSizes":{
+                "pSmall":0.7,
+                "pMed":0.2,
+                "pLarge":0.1
+            },
             "offices":250,
             "officeSizes":{
-                "pSmall":0.25,
-                "pMed":0.4,
-                "pLarge":0.35
+                "pSmall":0.2,
+                "pMed":0.3,
+                "pLarge":0.5
             },
             "constructionSites":1000,
+            "constructionSiteSizes":{
+                "pSmall":0.75,
+                "pMed":0.2,
+                "pLarge":0.1
+            },
             "nurseries":2000,
-            "restaurants":1000
+            "nurserySizes":{
+                "pSmall":0,
+                "pMed":1,
+                "pLarge":0
+            },
+            "restaurants":1000,
+            "restaurantSizes":{
+                "pSmall":0.3,
+                "pMed":0.6,
+                "pLarge":0.1
+            }
         },
         "workerAllocation":{
             "pOffice":0.2,

--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -81,7 +81,12 @@
             "pConstruction":0.1,
             "pTeacher":0.2,
             "pRestaurant":0.1,
-            "pUnemployed":0.2
+            "pUnemployed":0.2,
+            "sizeAllocation":{
+                "pSmall": 0.2,
+                "pMed": 0.3,
+                "pLarge": 0.5
+            }
         },
         "buildingProperties":{
             "pBaseTrans":0.45,

--- a/src/main/java/uk/co/ramp/covid/simulation/Covid.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Covid.java
@@ -41,6 +41,7 @@ public class Covid {
         this.infCounter = 0;
         this.setPeriods();
 
+        this.latent = true;
     }
 
     public boolean isLatent() {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -22,6 +22,12 @@ public abstract class CommunalPlace extends Place {
 
     private static final Logger LOGGER = LogManager.getLogger(CommunalPlace.class);
 
+    public enum Size {
+        SMALL, MED, LARGE, UNKNOWN;
+    }
+    
+    protected Size size;
+
     protected int startTime;
     protected int endTime;
     protected int startDay;
@@ -30,6 +36,11 @@ public abstract class CommunalPlace extends Place {
     protected double keyProb;
 
     protected final RandomDataGenerator rng;
+
+    public CommunalPlace(Size s) {
+        this();
+        size = s;
+    }
 
     public CommunalPlace() {
         super();
@@ -74,6 +85,13 @@ public abstract class CommunalPlace extends Place {
 
     public void adjustSDist(double sVal) {
         this.sDistance = sVal;
+    }
+
+    public Size getSize() {
+        return size;
+    }
+    public void setSize(Size s) {
+        size = s;
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
@@ -6,6 +6,11 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 public class ConstructionSite extends CommunalPlace {
 
     public ConstructionSite() {
+        this(Size.UNKNOWN);
+    }
+    
+    public ConstructionSite(Size s) {
+        super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpConstructionSiteTrans();
         keyProb = PopulationParameters.get().getpConstructionSiteKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -6,6 +6,11 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 public class Hospital extends CommunalPlace {
 
     public Hospital() {
+        this(Size.UNKNOWN);
+    }
+
+    public Hospital(Size s) {
+        super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpHospitalTrans();
         startDay = 3; //Bodge set start day to a different day of the week to help syncing
         endDay = 7;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
@@ -4,7 +4,13 @@ import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 public class Nursery extends CommunalPlace {
+
     public Nursery() {
+        this(Size.UNKNOWN);
+    }
+
+    public Nursery(Size s) {
+        super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpNurseryTrans();
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -4,15 +4,36 @@ import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 public class Office extends CommunalPlace {
+
+    public enum OfficeSize {
+        SMALL, MED, LARGE, UNKNOWN;
+    }
+
+    private OfficeSize size;
+
+    public Office(OfficeSize s) {
+        this();
+        size = s;
+    }
+
     public Office() {
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpOfficeTrans();
         keyProb = PopulationParameters.get().getpOfficeKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;
+        size = OfficeSize.UNKNOWN;
     }
 
     @Override
     public void reportInfection(DailyStats s) {
         s.incInfectionOffice();
+    }
+    
+    public OfficeSize getSize() {
+        return size;
+    }
+
+    public void setSize(OfficeSize s) {
+        size = s;
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -5,35 +5,20 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 public class Office extends CommunalPlace {
 
-    public enum OfficeSize {
-        SMALL, MED, LARGE, UNKNOWN;
-    }
-
-    private OfficeSize size;
-
-    public Office(OfficeSize s) {
-        this();
-        size = s;
-    }
-
     public Office() {
+        this(Size.UNKNOWN);
+    }
+
+    public Office(Size s)  {
+        super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpOfficeTrans();
         keyProb = PopulationParameters.get().getpOfficeKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;
-        size = OfficeSize.UNKNOWN;
     }
 
     @Override
     public void reportInfection(DailyStats s) {
         s.incInfectionOffice();
-    }
-    
-    public OfficeSize getSize() {
-        return size;
-    }
-
-    public void setSize(OfficeSize s) {
-        size = s;
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -7,7 +7,13 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 import java.util.ArrayList;
 
 public class Restaurant extends CommunalPlace {
+
     public Restaurant() {
+        this(Size.UNKNOWN);
+    }
+    
+    public Restaurant(Size s) {
+        super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpRestaurantTrans();
         startDay = 1;
         endDay = 7;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -5,6 +5,11 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 public class School extends CommunalPlace {
     public School() {
+        this(Size.UNKNOWN);
+    }
+
+    public School(Size s) {
+        super(s);
         int startTime = 9; // TODO. Not used at the moment, but may be used in the future. LEave them in for completeness
         int endTime = 15;
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpSchoolTrans();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -7,7 +7,13 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 import java.util.ArrayList;
 
 public class Shop extends CommunalPlace {
+
     public Shop() {
+        this(Size.UNKNOWN);
+    }
+
+    public Shop(Size s) {
+        super(s);
         transProb = PopulationParameters.get().getpBaseTrans() *  PopulationParameters.get().getpShopTrans();
         startDay = 1;
         endDay = 7;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
@@ -13,123 +13,53 @@ import java.util.function.Function;
 public class Places {
 
     private ProbabilityDistribution<Office> offices;
-    private List<ConstructionSite> constructionSites;
-    private List<Hospital> hospitals;
-    private List<Nursery> nurseries;
-    private List<Restaurant> restaurants;
-    private List<School> schools;
-    private List<Shop> shops;
-
-    public List<Office> getOffices() {
-        return offices.toList();
-    }
-
-    public List<ConstructionSite> getConstructionSites() {
-        return constructionSites;
-    }
-
-    public List<Hospital> getHospitals() {
-        return hospitals;
-    }
-
-    public List<Nursery> getNurseries() {
-        return nurseries;
-    }
-
-    public List<Restaurant> getRestaurants() {
-        return restaurants;
-    }
-
-    public List<School> getSchools() {
-        return schools;
-    }
-
-    public List<Shop> getShops() {
-        return shops;
-    }
-
-    public List<CommunalPlace> getAll() {
-        return all;
-    }
+    private ProbabilityDistribution<ConstructionSite> constructionSites;
+    private ProbabilityDistribution<Hospital> hospitals;
+    private ProbabilityDistribution<Nursery> nurseries;
+    private ProbabilityDistribution<Restaurant> restaurants;
+    private ProbabilityDistribution<School> schools;
+    private ProbabilityDistribution<Shop> shops;
 
     private List<CommunalPlace> all;
 
     public Places() {
         offices = new ProbabilityDistribution<>();
-        constructionSites = new ArrayList<>();
-        hospitals = new ArrayList<>();
-        nurseries = new ArrayList<>();
-        restaurants = new ArrayList<>();
-        schools = new ArrayList<>();
-        shops = new ArrayList<>();
+        constructionSites = new ProbabilityDistribution<>();
+        hospitals = new ProbabilityDistribution<>();
+        nurseries = new ProbabilityDistribution<>();
+        restaurants = new ProbabilityDistribution<>();
+        schools = new ProbabilityDistribution<>();
+        shops = new ProbabilityDistribution<>();
         all = new ArrayList<>();
     }
-
-    public void addConstructionSite(ConstructionSite s) {
-        constructionSites.add(s);
-        all.add(s);
-    }
-
-    public void addHospital(Hospital h) {
-        hospitals.add(h);
-        all.add(h);
-    }
-
-    public void addNursery(Nursery n) {
-        nurseries.add(n);
-        all.add(n);
-    }
-
-    public void addRestaurant(Restaurant r) {
-        restaurants.add(r);
-        all.add(r);
-    }
-
-    public void addSchool(School s) {
-        schools.add(s);
-        all.add(s);
-    }
-
-    public void addShop(Shop s) {
-        shops.add(s);
-        all.add(s);
-    }
-
-    // We often need a random place
-    private <T> T getRandom(List<T> s) {
-        if (s.size() > 0) {
-            int i = (int) RNG.get().nextInt(0, s.size() - 1);
-            return s.get(i);
-        }
-        return null;
-    }
+    
 
     public Office getRandomOffice() {
         return offices.sample();
     }
 
     public ConstructionSite getRandomConstructionSite() {
-        return getRandom(constructionSites);
+        return constructionSites.sample();
     }
 
     public Hospital getRandomHospital() {
-        return getRandom(hospitals);
+        return hospitals.sample();
     }
 
     public Nursery getRandomNursery() {
-        return getRandom(nurseries);
+        return nurseries.sample();
     }
 
     public Restaurant getRandomRestaurant() {
-        return getRandom(restaurants);
+        return restaurants.sample();
     }
 
     public School getRandomSchool() {
-        return getRandom(schools);
+        return schools.sample();
     }
 
     public Shop getRandomShop() {
-        return getRandom(shops);
+        return shops.sample();
     }
 
     private <T extends CommunalPlace> void createNGeneric(
@@ -155,10 +85,47 @@ public class Places {
             }
             places.add(constructor.apply(size));
         }
+        
+        double lprob =  PopulationParameters.get().getpAllocateLarge();
+        double mprob =  PopulationParameters.get().getpAllocateMed();
+        double sprob =  PopulationParameters.get().getpAllocateSmall();
 
-        double pl = PopulationParameters.get().getpAllocateLarge() / l;
-        double pm = PopulationParameters.get().getpAllocateMed() / m;
-        double ps = PopulationParameters.get().getpAllocateSmall() / s;
+        // In the case of 0 buildings we need to expand the probabilities to fill the distribution
+        if (l == 0 && m == 0) {
+            sprob = 1;
+        }
+        else if (l == 0 && s == 0) {
+            mprob = 1;
+        }
+        else if (m == 0 && s == 0) {
+            lprob = 1;
+        }
+        else if (l == 0) {
+            sprob += lprob/2;
+            mprob += lprob/2;
+        }
+        else if (m == 0) {
+            sprob += mprob/2;
+            lprob += mprob/2;
+        }
+        else if (s == 0) {
+            mprob += sprob/2;
+            lprob += sprob/2;
+        }
+
+        double pl = 0;
+        double pm = 0;
+        double ps = 0;
+
+        if (l > 0) {
+            pl = lprob / l;
+        }
+        if (m > 0) {
+            pm = mprob / m;
+        }
+        if (s > 0) {
+            ps = sprob / s;
+        }
 
         for (T p : places) {
             switch (p.getSize()) {
@@ -185,41 +152,81 @@ public class Places {
     }
 
     public void createNHospitals(int n) {
-        for (int i = 0; i < n; i++) {
-            addHospital(new Hospital());
-        }
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        p.add(PopulationParameters.get().getpHospitalSmall(), CommunalPlace.Size.SMALL);
+        p.add(PopulationParameters.get().getpHospitalMed(), CommunalPlace.Size.MED);
+        p.add(PopulationParameters.get().getpHospitalLarge(), CommunalPlace.Size.LARGE);
+        createNGeneric(s -> new Hospital(s), n, p, hospitals);
     }
 
     public void createNSchools(int n) {
-        for (int i = 0; i < n; i++) {
-            addSchool(new School());
-        }
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        p.add(PopulationParameters.get().getpSchoolSmall(), CommunalPlace.Size.SMALL);
+        p.add(PopulationParameters.get().getpSchoolMed(), CommunalPlace.Size.MED);
+        p.add(PopulationParameters.get().getpSchoolLarge(), CommunalPlace.Size.LARGE);
+        createNGeneric(s -> new School(s), n, p, schools);
     }
     public void createNNurseries(int n) {
-        for (int i = 0; i < n; i++) {
-            addNursery(new Nursery());
-        }
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        p.add(PopulationParameters.get().getpNurserySmall(), CommunalPlace.Size.SMALL);
+        p.add(PopulationParameters.get().getpNurseryMed(), CommunalPlace.Size.MED);
+        p.add(PopulationParameters.get().getpNurseryLarge(), CommunalPlace.Size.LARGE);
+        createNGeneric(s -> new Nursery(s), n, p, nurseries);
     }
 
     public void createNRestaurants(int n) {
-        for (int i = 0; i < n; i++) {
-            addRestaurant(new Restaurant());
-        }
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        p.add(PopulationParameters.get().getpRestaurantSmall(), CommunalPlace.Size.SMALL);
+        p.add(PopulationParameters.get().getpRestaurantMed(), CommunalPlace.Size.MED);
+        p.add(PopulationParameters.get().getpRestaurantLarge(), CommunalPlace.Size.LARGE);
+        createNGeneric(s -> new Restaurant(s), n, p, restaurants);
     }
 
     public void createNShops(int n) {
-        for (int i = 0; i < n; i++) {
-            addShop(new Shop());
-        }
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        p.add(PopulationParameters.get().getpShopSmall(), CommunalPlace.Size.SMALL);
+        p.add(PopulationParameters.get().getpShopMed(), CommunalPlace.Size.MED);
+        p.add(PopulationParameters.get().getpShopLarge(), CommunalPlace.Size.LARGE);
+        createNGeneric(s -> new Shop(s), n, p, shops);
     }
 
     public void createNConstructionSites(int n) {
-        for (int i = 0; i < n; i++) {
-            addConstructionSite(new ConstructionSite());
-        }
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        p.add(PopulationParameters.get().getpConstructionSiteSmall(), CommunalPlace.Size.SMALL);
+        p.add(PopulationParameters.get().getpConstructionSiteMed(), CommunalPlace.Size.MED);
+        p.add(PopulationParameters.get().getpConstructionSiteLarge(), CommunalPlace.Size.LARGE);
+        createNGeneric(s -> new ConstructionSite(s), n, p, constructionSites);
     }
 
     public List<CommunalPlace> getAllPlaces() {
         return this.all;
+    }
+
+    public List<Office> getOffices() {
+        return offices.toList();
+    }
+
+    public List<ConstructionSite> getConstructionSites() {
+        return constructionSites.toList();
+    }
+
+    public List<Hospital> getHospitals() {
+        return hospitals.toList();
+    }
+
+    public List<Nursery> getNurseries() {
+        return nurseries.toList();
+    }
+
+    public List<Restaurant> getRestaurants() {
+        return restaurants.toList();
+    }
+
+    public List<School> getSchools() {
+        return schools.toList();
+    }
+
+    public List<Shop> getShops() {
+        return shops.toList();
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
@@ -151,10 +151,9 @@ public class Places {
         }
 
         // Create a scaled distribution such that large is more common than med etc
-        // Division in multiples of 3 to create 3 uniform classes
-        double pl = (2.0/3)/l;
-        double pm = (2.0/9)/m;
-        double ps = (1.0/9)/s;
+        double pl = PopulationParameters.get().getpAllocateLarge()/l;
+        double pm = PopulationParameters.get().getpAllocateMed()/m;
+        double ps = PopulationParameters.get().getpAllocateSmall()/s;
 
         for (Office o : os) {
             switch (o.getSize()) {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
@@ -17,6 +17,7 @@ public class PopulationParameters {
     private static final Logger LOGGER = LogManager.getLogger(PopulationParameters.class);
     private static PopulationParameters pp = null;
 
+
     // Proportions of each type of person in the population
     private static class Population {
         public Double pInfants = null;
@@ -80,12 +81,22 @@ public class PopulationParameters {
 
     }
 
+    private static class BuildingSize {
+        public Double pSmall = null;
+        public Double pMed = null;
+        public Double pLarge = null;
+    }
+
+
     // Defines the number of types of building per N people
     private static class BuildingDistribution {
         public Integer hospitals = null;
         public Integer schools = null;
         public Integer shops = null;
+
         public Integer offices = null;
+        public BuildingSize officeSizes = null;
+
         public Integer constructionSites = null;
         public Integer nurseries = null;
         public Integer restaurants = null;
@@ -327,6 +338,18 @@ public class PopulationParameters {
         return buildingDistribution.offices;
     }
 
+    public double getpOfficeSmall() {
+        return buildingDistribution.officeSizes.pSmall;
+    }
+
+    public double getpOfficeMed() {
+        return buildingDistribution.officeSizes.pMed;
+    }
+
+    public double getpOfficeLarge() {
+        return buildingDistribution.officeSizes.pLarge;
+    }
+
     public int getConstructionSiteRatio() {
         return buildingDistribution.constructionSites;
     }
@@ -439,6 +462,8 @@ public class PopulationParameters {
     public double getpTransmission() {
         return personProperties.pTransmission;
     }
+
+
 
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
@@ -81,7 +81,7 @@ public class PopulationParameters {
 
     }
 
-    private static class BuildingSize {
+    private static class Size {
         public Double pSmall = null;
         public Double pMed = null;
         public Double pLarge = null;
@@ -95,7 +95,7 @@ public class PopulationParameters {
         public Integer shops = null;
 
         public Integer offices = null;
-        public BuildingSize officeSizes = null;
+        public Size officeSizes = null;
 
         public Integer constructionSites = null;
         public Integer nurseries = null;
@@ -124,6 +124,8 @@ public class PopulationParameters {
         public Double pTeacher = null;
         public Double pRestaurant = null;
         public Double pUnemployed = null;
+
+        public Size sizeAllocation = null;
 
         @Override
         public String toString() {
@@ -365,6 +367,16 @@ public class PopulationParameters {
     // Worker job assignment probabilities
     public double getpOfficeWorker() {
         return workerAllocation.pOffice;
+    }
+
+    public double getpAllocateSmall() {
+        return workerAllocation.sizeAllocation.pSmall;
+    }
+    public double getpAllocateMed() {
+        return workerAllocation.sizeAllocation.pMed;
+    }
+    public double getpAllocateLarge() {
+        return workerAllocation.sizeAllocation.pLarge;
     }
 
     public double getpShopWorker() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
@@ -91,15 +91,25 @@ public class PopulationParameters {
     // Defines the number of types of building per N people
     private static class BuildingDistribution {
         public Integer hospitals = null;
+        public Size hospitalSizes = null;
+
         public Integer schools = null;
+        public Size schoolSizes = null;
+
         public Integer shops = null;
+        public Size shopSizes = null;
 
         public Integer offices = null;
         public Size officeSizes = null;
 
         public Integer constructionSites = null;
+        public Size constructionSiteSizes = null;
+
         public Integer nurseries = null;
+        public Size nurserySizes = null;
+
         public Integer restaurants = null;
+        public Size restaurantSizes = null;
 
         @Override
         public String toString() {
@@ -328,12 +338,48 @@ public class PopulationParameters {
         return buildingDistribution.hospitals;
     }
 
+    public double getpHospitalSmall() {
+        return buildingDistribution.hospitalSizes.pSmall;
+    }
+
+    public double getpHospitalMed() {
+        return buildingDistribution.hospitalSizes.pMed;
+    }
+
+    public double getpHospitalLarge() {
+        return buildingDistribution.hospitalSizes.pLarge;
+    }
+
     public int getSchoolsRatio() {
         return buildingDistribution.schools;
     }
 
+    public double getpSchoolSmall() {
+        return buildingDistribution.schoolSizes.pSmall;
+    }
+
+    public double getpSchoolMed() {
+        return buildingDistribution.schoolSizes.pMed;
+    }
+
+    public double getpSchoolLarge() {
+        return buildingDistribution.schoolSizes.pLarge;
+    }
+
     public int getShopsRatio() {
         return buildingDistribution.shops;
+    }
+
+    public double getpShopSmall() {
+        return buildingDistribution.shopSizes.pSmall;
+    }
+
+    public double getpShopMed() {
+        return buildingDistribution.shopSizes.pMed;
+    }
+
+    public double getpShopLarge() {
+        return buildingDistribution.shopSizes.pLarge;
     }
 
     public int getOfficesRatio() {
@@ -356,12 +402,48 @@ public class PopulationParameters {
         return buildingDistribution.constructionSites;
     }
 
+    public double getpConstructionSiteSmall() {
+        return buildingDistribution.constructionSiteSizes.pSmall;
+    }
+
+    public double getpConstructionSiteMed() {
+        return buildingDistribution.constructionSiteSizes.pMed;
+    }
+
+    public double getpConstructionSiteLarge() {
+        return buildingDistribution.constructionSiteSizes.pLarge;
+    }
+
     public int getNurseriesRatio() {
         return buildingDistribution.nurseries;
     }
 
+    public double getpNurserySmall() {
+        return buildingDistribution.nurserySizes.pSmall;
+    }
+
+    public double getpNurseryMed() {
+        return buildingDistribution.nurserySizes.pMed;
+    }
+
+    public double getpNurseryLarge() {
+        return buildingDistribution.nurserySizes.pLarge;
+    }
+
     public int getRestaurantRatio() {
         return buildingDistribution.restaurants;
+    }
+
+    public double getpRestaurantSmall() {
+        return buildingDistribution.restaurantSizes.pSmall;
+    }
+
+    public double getpRestaurantMed() {
+        return buildingDistribution.restaurantSizes.pMed;
+    }
+
+    public double getpRestaurantLarge() {
+        return buildingDistribution.restaurantSizes.pLarge;
     }
 
     // Worker job assignment probabilities

--- a/src/main/java/uk/co/ramp/covid/simulation/util/ProbabilityDistribution.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/ProbabilityDistribution.java
@@ -63,4 +63,13 @@ public class ProbabilityDistribution<T> {
         }
         return null;
     }
+
+    public List<T> toList() {
+        List<T> l = new ArrayList<>();
+        for (ProbPair p : pmap) {
+            l.add(p.val);
+        }
+        return l;
+    }
+
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -58,9 +58,8 @@ public class ModelTest {
             cummulativeI = s.getTotalInfected() + s.getRecovered() + s.getDead();
             totalDailyInfects += s.getTotalDailyInfections();
             assertEquals(s.getHealthy(), population - cummulativeI);
+            assertEquals(cummulativeI, totalDailyInfects);
         }
-
-        assertEquals(cummulativeI, totalDailyInfects);
 
         // Deaths should be proportional to phase2 progression
         int adultDeaths = 0;

--- a/src/test/java/uk/co/ramp/covid/simulation/io/ParameterReaderTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/io/ParameterReaderTest.java
@@ -88,6 +88,10 @@ public class ParameterReaderTest {
         assertEquals(0.7, PopulationParameters.get().getpQuarantine(), EPSILON);
 
         assertEquals(0.8, PopulationParameters.get().getHouseholdVisitorLeaveRate(), EPSILON);
+
+        assertEquals(0.25, PopulationParameters.get().getpOfficeSmall(), EPSILON);
+        assertEquals(0.4, PopulationParameters.get().getpOfficeMed(), EPSILON);
+        assertEquals(0.35, PopulationParameters.get().getpOfficeLarge(), EPSILON);
     }
 
     @After

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
@@ -73,9 +73,9 @@ public class PlacesTest {
         assertTrue("We should sample large offices more often than medium", l > m);
         assertTrue("We should sample medium offices more often than small", m > s);
 
-        int DELTA = (int) iters*0.5; // Allow a 5% delta
-        assertTrue("We sample large offices almost three times as often as medium", l - DELTA <= m*3 && l + DELTA >= m*3);
-        assertTrue("We sample large offices almost six times as often as small", l - DELTA <= s*6 && l + DELTA >= s*6);
-        assertTrue("We sample medium offices almost two times as often as small", m - DELTA <= s*2 && m + DELTA >= s*2);
+        double DELTA = 0.02;
+        assertEquals(PopulationParameters.get().getpOfficeLarge(),  (double) l/ (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpOfficeMed(), (double) m / (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpOfficeSmall(), (double) s / (double) iters, DELTA);
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
@@ -1,0 +1,81 @@
+package uk.co.ramp.covid.simulation.population;
+
+import com.sun.source.tree.AssertTree;
+import org.junit.Before;
+import org.junit.Test;
+import uk.co.ramp.covid.simulation.io.ParameterReader;
+import uk.co.ramp.covid.simulation.place.Office;
+import uk.co.ramp.covid.simulation.util.RNG;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class PlacesTest {
+
+    @Before
+    public void setupParams() throws IOException {
+        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
+        // NOTE: This test is no guarenteed to pass with a different seed due to randomness
+        RNG.seed(42);
+    }
+
+    @Test
+    public void createNOffices() {
+        int n = 100;
+        
+        Places p = new Places();
+        p.createNOffices(n);
+
+        int s = 0, m = 0, l = 0;
+        for (Office o : p.getOffices()) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        // Test params = pSmall: 0.2, pMed: 0.3, pLarge:0.5
+        assertEquals(n, s + m + l);
+        assertEquals(20, s, 5);
+        assertEquals(30, m, 5);
+        assertEquals(50, l, 5);
+    }
+
+    @Test
+    public void getRandomOffice() {
+        int n = 100;
+        int iters = 10000; // Number of samples to try
+        Places p = new Places();
+        p.createNOffices(n);
+
+        // Should be most likely to get larger offices
+        List<Office> samples = new ArrayList<>();
+        for (int i = 0; i < iters ; i++) {
+            samples.add(p.getRandomOffice());
+        }
+
+        int s = 0, m = 0, l = 0;
+        for (Office o : samples) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        assertTrue("We should sample each office size at least once", s > 0 && m > 0 && l > 0);
+        assertTrue("We should sample large offices more often than small", l > s);
+        assertTrue("We should sample large offices more often than medium", l > m);
+        assertTrue("We should sample medium offices more often than small", m > s);
+
+        int DELTA = (int) iters*0.5; // Allow a 5% delta
+        assertTrue("We sample large offices almost three times as often as medium", l - DELTA <= m*3 && l + DELTA >= m*3);
+        assertTrue("We sample large offices almost six times as often as small", l - DELTA <= s*6 && l + DELTA >= s*6);
+        assertTrue("We sample medium offices almost two times as often as small", m - DELTA <= s*2 && m + DELTA >= s*2);
+    }
+}

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
@@ -4,7 +4,7 @@ import com.sun.source.tree.AssertTree;
 import org.junit.Before;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
-import uk.co.ramp.covid.simulation.place.Office;
+import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
@@ -23,28 +23,6 @@ public class PlacesTest {
         RNG.seed(42);
     }
 
-    @Test
-    public void createNOffices() {
-        int n = 100;
-        
-        Places p = new Places();
-        p.createNOffices(n);
-
-        int s = 0, m = 0, l = 0;
-        for (Office o : p.getOffices()) {
-            switch (o.getSize()) {
-                case SMALL: s++; break;
-                case MED: m++; break;
-                case LARGE: l++; break;
-            }
-        }
-
-        // Test params = pSmall: 0.2, pMed: 0.3, pLarge:0.5
-        assertEquals(n, s + m + l);
-        assertEquals(20, s, 5);
-        assertEquals(30, m, 5);
-        assertEquals(50, l, 5);
-    }
 
     @Test
     public void getRandomOffice() {
@@ -53,7 +31,6 @@ public class PlacesTest {
         Places p = new Places();
         p.createNOffices(n);
 
-        // Should be most likely to get larger offices
         List<Office> samples = new ArrayList<>();
         for (int i = 0; i < iters ; i++) {
             samples.add(p.getRandomOffice());
@@ -74,8 +51,432 @@ public class PlacesTest {
         assertTrue("We should sample medium offices more often than small", m > s);
 
         double DELTA = 0.02;
-        assertEquals(PopulationParameters.get().getpOfficeLarge(),  (double) l/ (double) iters, DELTA);
-        assertEquals(PopulationParameters.get().getpOfficeMed(), (double) m / (double) iters, DELTA);
-        assertEquals(PopulationParameters.get().getpOfficeSmall(), (double) s / (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpAllocateLarge(),  (double) l/ (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpAllocateMed(), (double) m / (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpAllocateSmall(), (double) s / (double) iters, DELTA);
+    }
+
+    @Test
+    public void getRandomConstructionSite() {
+        int n = 100;
+        int iters = 10000; // Number of samples to try
+        Places p = new Places();
+        p.createNConstructionSites(n);
+
+        List<ConstructionSite> samples = new ArrayList<>();
+        for (int i = 0; i < iters ; i++) {
+            samples.add(p.getRandomConstructionSite());
+        }
+
+        int s = 0, m = 0, l = 0;
+        for (ConstructionSite o : samples) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        assertTrue("We should sample each constructionSite size at least once", s > 0 && m > 0 && l > 0);
+        assertTrue("We should sample large constructionSites more often than small", l > s);
+        assertTrue("We should sample large constructionSites more often than medium", l > m);
+        assertTrue("We should sample medium constructionSites more often than small", m > s);
+
+        double DELTA = 0.02;
+        assertEquals(PopulationParameters.get().getpAllocateLarge(),  (double) l/ (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpAllocateMed(), (double) m / (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpAllocateSmall(), (double) s / (double) iters, DELTA);
+    }
+
+    @Test
+    public void getRandomHospital() {
+        int n = 100;
+        int iters = 10000; // Number of samples to try
+        Places p = new Places();
+        p.createNHospitals(n);
+
+        List<Hospital> samples = new ArrayList<>();
+        for (int i = 0; i < iters ; i++) {
+            samples.add(p.getRandomHospital());
+        }
+
+        int s = 0, m = 0, l = 0;
+        for (Hospital o : samples) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        assertTrue("We only have medium hospitals", s == 0 && m > 0 && l == 0);
+        assertEquals(iters, m);
+    }
+
+    @Test
+    public void getRandomNursery() {
+        int n = 100;
+        int iters = 10000; // Number of samples to try
+        Places p = new Places();
+        p.createNNurseries(n);
+
+        List<Nursery> samples = new ArrayList<>();
+        for (int i = 0; i < iters ; i++) {
+            samples.add(p.getRandomNursery());
+        }
+
+        int s = 0, m = 0, l = 0;
+        for (Nursery o : samples) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        assertTrue("We only have medium nurseries", s == 0 && m > 0 && l == 0);
+        assertEquals(iters, m);
+    }
+
+    @Test
+    public void getRandomRestaurant() {
+        int n = 100;
+        int iters = 10000; // Number of samples to try
+        Places p = new Places();
+        p.createNRestaurants(n);
+
+        List<Restaurant> samples = new ArrayList<>();
+        for (int i = 0; i < iters ; i++) {
+            samples.add(p.getRandomRestaurant());
+        }
+
+        int s = 0, m = 0, l = 0;
+        for (Restaurant o : samples) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        assertTrue("We should sample each restaurant size at least once", s > 0 && m > 0 && l > 0);
+        assertTrue("We should sample large restaurants more often than small", l > s);
+        assertTrue("We should sample large restaurants more often than medium", l > m);
+        assertTrue("We should sample medium restaurants more often than small", m > s);
+
+        double DELTA = 0.02;
+        assertEquals(PopulationParameters.get().getpAllocateLarge(),  (double) l/ (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpAllocateMed(), (double) m / (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpAllocateSmall(), (double) s / (double) iters, DELTA);
+    }
+
+    @Test
+    public void getRandomSchool() {
+        int n = 100;
+        int iters = 10000; // Number of samples to try
+        Places p = new Places();
+        p.createNSchools(n);
+
+        List<School> samples = new ArrayList<>();
+        for (int i = 0; i < iters ; i++) {
+            samples.add(p.getRandomSchool());
+        }
+
+        int s = 0, m = 0, l = 0;
+        for (School o : samples) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        assertTrue("We only have medium school size", s == 0 && m > 0 && l == 0);
+        assertEquals(iters, m);
+    }
+
+    @Test
+    public void getRandomShop() {
+        int n = 100;
+        int iters = 10000; // Number of samples to try
+        Places p = new Places();
+        p.createNShops(n);
+
+        List<Shop> samples = new ArrayList<>();
+        for (int i = 0; i < iters ; i++) {
+            samples.add(p.getRandomShop());
+        }
+
+        int s = 0, m = 0, l = 0;
+        for (Shop o : samples) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        assertTrue("We should sample each shop size at least once", s > 0 && m > 0 && l > 0);
+        assertTrue("We should sample large shops more often than small", l > s);
+        assertTrue("We should sample large shops more often than medium", l > m);
+        assertTrue("We should sample medium shops more often than small", m > s);
+
+        double DELTA = 0.02;
+        assertEquals(PopulationParameters.get().getpAllocateLarge(),  (double) l/ (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpAllocateMed(), (double) m / (double) iters, DELTA);
+        assertEquals(PopulationParameters.get().getpAllocateSmall(), (double) s / (double) iters, DELTA);
+    }
+
+    @Test
+    public void createNOffices() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNOffices(n);
+
+        int s = 0, m = 0, l = 0;
+        for (Office o : p.getOffices()) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        // Test params = pSmall: 0.2, pMed: 0.3, pLarge:0.5
+        assertEquals(n, s + m + l);
+        assertEquals(n * PopulationParameters.get().getpOfficeSmall(), s, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpOfficeMed(), m, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpOfficeLarge(), l, n*0.05);
+    }
+
+    @Test
+    public void createNHospitals() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNHospitals(n);
+
+        int s = 0, m = 0, l = 0;
+        for (Hospital o : p.getHospitals()) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        // Test params = pSmall: 0.2, pMed: 0.3, pLarge:0.5
+        assertEquals(n, s + m + l);
+        assertEquals(n * PopulationParameters.get().getpHospitalSmall(), s, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpHospitalMed(), m, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpHospitalLarge(), l, n*0.05);
+    }
+
+    @Test
+    public void createNSchools() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNSchools(n);
+
+        int s = 0, m = 0, l = 0;
+        for (School o : p.getSchools()) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        // Test params = pSmall: 0.2, pMed: 0.3, pLarge:0.5
+        assertEquals(n, s + m + l);
+        assertEquals(n * PopulationParameters.get().getpSchoolSmall(), s, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpSchoolMed(), m, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpSchoolLarge(), l, n*0.05);
+    }
+
+    @Test
+    public void createNNurseries() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNNurseries(n);
+
+        int s = 0, m = 0, l = 0;
+        for (Nursery o : p.getNurseries()) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        // Test params = pSmall: 0.2, pMed: 0.3, pLarge:0.5
+        assertEquals(n, s + m + l);
+        assertEquals(n * PopulationParameters.get().getpNurserySmall(), s, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpNurseryMed(), m, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpNurseryLarge(), l, n*0.05);
+    }
+
+    @Test
+    public void createNRestaurants() {
+        int n = 10000;
+        Places p = new Places();
+        p.createNRestaurants(n);
+
+        int s = 0, m = 0, l = 0;
+        for (Restaurant o : p.getRestaurants()) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        assertEquals(n, s + m + l);
+        assertEquals(n * PopulationParameters.get().getpRestaurantSmall(), s, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpRestaurantMed(), m, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpRestaurantLarge(), l, n*0.05);
+    }
+
+    @Test
+    public void createNShops() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNShops(n);
+
+        int s = 0, m = 0, l = 0;
+        for (Shop o : p.getShops()) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        // Test params = pSmall: 0.2, pMed: 0.3, pLarge:0.5
+        assertEquals(n, s + m + l);
+        assertEquals(n * PopulationParameters.get().getpShopSmall(), s, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpShopMed(), m, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpShopLarge(), l, n*0.05);
+    }
+
+    @Test
+    public void createNConstructionSites() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNConstructionSites(n);
+
+        int s = 0, m = 0, l = 0;
+        for (ConstructionSite o : p.getConstructionSites()) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        // Test params = pSmall: 0.2, pMed: 0.3, pLarge:0.5
+        assertEquals(n, s + m + l);
+        assertEquals(n * PopulationParameters.get().getpConstructionSiteSmall(), s, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpConstructionSiteMed(), m, n*0.05);
+        assertEquals(n * PopulationParameters.get().getpConstructionSiteLarge(), l, n*0.05);
+    }
+
+    @Test
+    public void getAllPlaces() {
+        int n = 100;
+        Places p = new Places();
+        p.createNOffices(n);
+        p.createNShops(n);
+        p.createNRestaurants(n);
+        p.createNNurseries(n);
+        p.createNHospitals(n);
+        p.createNConstructionSites(n);
+        p.createNSchools(n);
+
+        assertEquals(n*7, p.getAllPlaces().size());
+        assertTrue(p.getAllPlaces().containsAll(p.getOffices()));
+        assertTrue(p.getAllPlaces().containsAll(p.getConstructionSites()));
+        assertTrue(p.getAllPlaces().containsAll(p.getHospitals()));
+        assertTrue(p.getAllPlaces().containsAll(p.getNurseries()));
+        assertTrue(p.getAllPlaces().containsAll(p.getRestaurants()));
+        assertTrue(p.getAllPlaces().containsAll(p.getSchools()));
+        assertTrue(p.getAllPlaces().containsAll(p.getShops()));
+
+    }
+
+    @Test
+    public void getOffices() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNOffices(n);
+        
+        List<Office> offices = p.getOffices();
+        assertEquals(n, offices.size());
+        assertTrue(p.getAllPlaces().containsAll(offices));
+    }
+
+    @Test
+    public void getConstructionSites() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNConstructionSites(n);
+
+        List<ConstructionSite> cs = p.getConstructionSites();
+        assertEquals(n, cs.size());
+        assertTrue(p.getAllPlaces().containsAll(cs));
+    }
+
+    @Test
+    public void getHospitals() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNHospitals(n);
+
+        List<Hospital> hs = p.getHospitals();
+        assertEquals(n, hs.size());
+        assertTrue(p.getAllPlaces().containsAll(hs));
+    }
+
+    @Test
+    public void getNurseries() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNNurseries(n);
+
+        List<Nursery> ns = p.getNurseries();
+        assertEquals(n, ns.size());
+        assertTrue(p.getAllPlaces().containsAll(ns));
+    }
+
+    @Test
+    public void getRestaurants() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNRestaurants(n);
+
+        List<Restaurant> rs = p.getRestaurants();
+        assertEquals(n, rs.size());
+        assertTrue(p.getAllPlaces().containsAll(rs));
+    }
+
+    @Test
+    public void getSchools() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNSchools(n);
+
+        List<School> ss = p.getSchools();
+        assertEquals(n, ss.size());
+        assertTrue(p.getAllPlaces().containsAll(ss));
+    }
+
+    @Test
+    public void getShops() {
+        int n = 1000;
+        Places p = new Places();
+        p.createNShops(n);
+
+        List<Shop> ss = p.getShops();
+        assertEquals(n, ss.size());
+        assertTrue(p.getAllPlaces().containsAll(ss));
     }
 }

--- a/src/test/resources/default_params.json
+++ b/src/test/resources/default_params.json
@@ -99,8 +99,8 @@
             },
             "restaurants":1000,
             "restaurantSizes":{
-                "pSmall":0.3,
-                "pMed":0.6,
+                "pSmall":0.4,
+                "pMed":0.5,
                 "pLarge":0.1
             }
         },

--- a/src/test/resources/default_params.json
+++ b/src/test/resources/default_params.json
@@ -65,6 +65,11 @@
             "schools":2000,
             "shops":500,
             "offices":250,
+            "officeSizes":{
+                "pSmall":0.2,
+                "pMed":0.3,
+                "pLarge":0.5
+            },
             "constructionSites":1000,
             "nurseries":2000,
             "restaurants":1000

--- a/src/test/resources/default_params.json
+++ b/src/test/resources/default_params.json
@@ -62,8 +62,23 @@
         },
         "buildingDistribution":{
             "hospitals":10000,
+            "hospitalSizes":{
+                "pSmall":0,
+                "pMed":1.0,
+                "pLarge":0
+            },
             "schools":2000,
+            "schoolSizes":{
+                "pSmall":0,
+                "pMed":1.0,
+                "pLarge":0
+            },
             "shops":500,
+            "shopSizes":{
+                "pSmall":0.7,
+                "pMed":0.2,
+                "pLarge":0.1
+            },
             "offices":250,
             "officeSizes":{
                 "pSmall":0.2,
@@ -71,8 +86,23 @@
                 "pLarge":0.5
             },
             "constructionSites":1000,
+            "constructionSiteSizes":{
+                "pSmall":0.7,
+                "pMed":0.2,
+                "pLarge":0.1
+            },
             "nurseries":2000,
-            "restaurants":1000
+            "nurserySizes":{
+                "pSmall":0,
+                "pMed":1,
+                "pLarge":0
+            },
+            "restaurants":1000,
+            "restaurantSizes":{
+                "pSmall":0.3,
+                "pMed":0.6,
+                "pLarge":0.1
+            }
         },
         "workerAllocation":{
             "pOffice":0.2,

--- a/src/test/resources/default_params.json
+++ b/src/test/resources/default_params.json
@@ -81,7 +81,12 @@
             "pConstruction":0.1,
             "pTeacher":0.2,
             "pRestaurant":0.1,
-            "pUnemployed":0.2
+            "pUnemployed":0.2,
+            "sizeAllocation":{
+                "pSmall": 0.2,
+                "pMed": 0.3,
+                "pLarge": 0.5
+            }
         },
         "buildingProperties":{
             "pBaseTrans":0.45,

--- a/src/test/resources/test_params.json
+++ b/src/test/resources/test_params.json
@@ -58,6 +58,11 @@
             "schools":500,
             "shops":200,
             "offices":100,
+            "officeSizes":{
+                "pSmall":0.25,
+                "pMed":0.4,
+                "pLarge":0.35
+            },
             "constructionSites":2000,
             "nurseries":3000,
             "restaurants":800

--- a/src/test/resources/test_params.json
+++ b/src/test/resources/test_params.json
@@ -74,7 +74,12 @@
             "pConstruction":0.1,
             "pTeacher":0.1,
             "pRestaurant":0.2,
-            "pUnemployed":0.1
+            "pUnemployed":0.1,
+            "sizeAllocation":{
+              "pSmall": 0.2,
+              "pMed": 0.3,
+              "pLarge": 0.5
+            }
         },
         "buildingProperties":{
             "pBaseTrans":0.8,

--- a/src/test/resources/test_params.json
+++ b/src/test/resources/test_params.json
@@ -58,14 +58,43 @@
             "schools":500,
             "shops":200,
             "offices":100,
-            "officeSizes":{
-                "pSmall":0.25,
-                "pMed":0.4,
-                "pLarge":0.35
-            },
             "constructionSites":2000,
             "nurseries":3000,
-            "restaurants":800
+            "restaurants":800,
+          "hospitalSizes":{
+            "pSmall":0,
+            "pMed":1.0,
+            "pLarge":0
+          },
+          "schoolSizes":{
+            "pSmall":0,
+            "pMed":1.0,
+            "pLarge":0
+          },
+          "shopSizes":{
+            "pSmall":0.7,
+            "pMed":0.2,
+            "pLarge":0.1
+          },
+          "officeSizes":{
+            "pSmall":0.25,
+            "pMed":0.4,
+            "pLarge":0.35},
+          "constructionSiteSizes":{
+            "pSmall":0.7,
+            "pMed":0.2,
+            "pLarge":0.1
+          },
+          "nurserySizes":{
+            "pSmall":0,
+            "pMed":1,
+            "pLarge":0
+          },
+          "restaurantSizes":{
+            "pSmall":0.3,
+            "pMed":0.6,
+            "pLarge":0.1
+          }
         },
         "workerAllocation":{
             "pOffice":0.1,


### PR DESCRIPTION
This allows a distribution of places sizes, and setting of probabilities such that when we request a random place (for example to go shopping or to allocate) we are biased towards larger venues. That is Large => Expected more people (rather than anything physical).

Currently we support Small/Medium/Large only (but this can be extended in future if required).