### PR TITLE
Tidy up Household

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -66,6 +66,8 @@ public class Household extends Place {
         neighbours.add(n);
     }
 
+    public boolean isNeighbour(Household n) { return neighbours.contains(n); }
+
     public boolean seedInfection() {
         List<Person> inhabitants = getInhabitants();
         Person cPers = inhabitants.get(RNG.get().nextInt(0, inhabitants.size() - 1));

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -1,15 +1,6 @@
-/*
- * Paul Bessell
- * This initilaises each Household as a Vector of People.
- * It has a method for cycling throuhg the Household to challenge wiht infection (when relevant)
- */
-
-
 package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.DailyStats;
-import org.apache.commons.math3.random.RandomDataGenerator;
-import uk.co.ramp.covid.simulation.RunModel;
 import uk.co.ramp.covid.simulation.population.CStatus;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
@@ -18,7 +9,6 @@ import uk.co.ramp.covid.simulation.util.RNG;
 import java.util.*;
 
 public class Household extends Place {
-
 
     public enum HouseholdType {
        ADULT               { public String toString() {return "Adult only";                   } },
@@ -41,13 +31,12 @@ public class Household extends Place {
             HouseholdType.ADULTCHILD, HouseholdType.ADULTPENSIONERCHILD, HouseholdType.PENSIONERCHILD));
 
     private final HouseholdType hType;
-    private List<Household> neighbours;
-    private final RandomDataGenerator rng;
+    private final List<Household> neighbours;
+    private int householdSize = 0;
 
     // Create household defined by who lives there
     public Household(HouseholdType hType) {
         this.hType = hType;
-        this.rng = RNG.get();
         this.neighbours = new ArrayList<>();
     }
 
@@ -65,11 +54,12 @@ public class Household extends Place {
 
     public void addInhabitant(Person cPers) {
         cPers.setHome(this);
+        householdSize++;
         this.people.add(cPers);
     }
 
     public int getHouseholdSize() {
-        return this.getInhabitants().size();
+        return householdSize;
     }
 
     public void addNeighbour(Household n) {
@@ -78,7 +68,7 @@ public class Household extends Place {
 
     public boolean seedInfection() {
         List<Person> inhabitants = getInhabitants();
-        Person cPers = inhabitants.get(rng.nextInt(0, inhabitants.size() - 1));
+        Person cPers = inhabitants.get(RNG.get().nextInt(0, inhabitants.size() - 1));
         return cPers.infect();
     }
 
@@ -118,7 +108,7 @@ public class Household extends Place {
         ArrayList<Person> left = new ArrayList<>();
 
         for (Person p : getVisitors()) {
-            if (rng.nextUniform(0, 1) < PopulationParameters.get().getHouseholdVisitorLeaveRate()) {
+            if (RNG.get().nextUniform(0, 1) < PopulationParameters.get().getHouseholdVisitorLeaveRate()) {
                 left.add(p);
                 if (p.cStatus() != CStatus.DEAD) {
                    p.returnHome();
@@ -176,7 +166,6 @@ public class Household extends Place {
     // For each household processes any movements to Communal Places that are relevant
     public void cycleMovements(int day, int hour, boolean lockdown) {
         List<Person> left = new ArrayList<>();
-        int i = 0;
         for (Person p : getInhabitants()) {
             if (p.hasPrimaryCommunalPlace() && !p.getQuarantine()) {
                 boolean visit = p.getPrimaryCommunalPlace().checkVisit(p, hour, day, lockdown);
@@ -187,6 +176,4 @@ public class Household extends Place {
         }
         people.removeAll(left);
     }
-    
-   
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -41,21 +41,22 @@ public class Household extends Place {
             HouseholdType.ADULTCHILD, HouseholdType.ADULTPENSIONERCHILD, HouseholdType.PENSIONERCHILD));
 
     private final HouseholdType hType;
-    private int[] neighbourList;
+    private List<Household> neighbours;
     private final RandomDataGenerator rng;
 
     // Create household defined by who lives there
     public Household(HouseholdType hType) {
         this.hType = hType;
         this.rng = RNG.get();
+        this.neighbours = new ArrayList<>();
     }
 
-    public int getNeighbourIndex(int nNeighbour) {
-        return this.neighbourList[nNeighbour];
+    public List<Household> getNeighbours() {
+        return neighbours;
     }
 
     public int nNeighbours() {
-        return this.neighbourList.length;
+        return neighbours.size();
     }
 
     public HouseholdType gethType() {
@@ -71,8 +72,8 @@ public class Household extends Place {
         return this.getInhabitants().size();
     }
 
-    public void setNeighbourList(int[] neighbours) {
-        this.neighbourList = neighbours;
+    public void addNeighbour(Household n) {
+        neighbours.add(n);
     }
 
     public boolean seedInfection() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -68,7 +68,7 @@ public abstract class Person {
     }
     
     public void returnHome() {
-        home.addPerson(this);
+        home.addInhabitant(this);
     }
 
     public boolean getQuarantine() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -130,7 +130,6 @@ public class Population {
                     break;
                 }
                 remainingPeople.clear(i);
-                aPopulation[i].setHome(population[h]);
                 population[h].addInhabitant(aPopulation[i]);
             }
         }
@@ -151,7 +150,6 @@ public class Population {
                         if (i < 0) {
                             break;
                         }
-                        aPopulation[i].setHome(population[h]);
                         population[h].addInhabitant(aPopulation[i]);
                         remainingPeople.clear(i);
                     }
@@ -254,7 +252,14 @@ public class Population {
 
                 Household neighbour = population[rng.nextInt(0, population.length - 1)];
 
+                // Cannot be a neighbour of ourselves
                 if (neighbour == cHouse) {
+                    k--;
+                    continue;
+                }
+
+                // Avoid duplicate neighbours
+                if (cHouse.isNeighbour(neighbour)) {
                     k--;
                     continue;
                 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -247,17 +247,20 @@ public class Population {
 
     // This method assigns a random number of neighbours to each Household
     public void assignNeighbours() {
-        for (int i = 0; i < this.nHousehold; i++) {
-            Household cHouse = this.population[i];
+        for (Household cHouse : population) {
             int expectedNeighbours = PopulationParameters.get().getExpectedNeighbours();
             int nneighbours = (int) rng.nextPoisson(expectedNeighbours);
-            int[] neighbourArray = new int[nneighbours];
             for (int k = 0; k < nneighbours; k++) {
-                int nInt = rng.nextInt(0, this.nHousehold - 1);
-                if (nInt == i) k--;
-                else neighbourArray[k] = nInt;
+
+                Household neighbour = population[rng.nextInt(0, population.length - 1)];
+
+                if (neighbour == cHouse) {
+                    k--;
+                    continue;
+                }
+
+                cHouse.addNeighbour(neighbour);
             }
-            cHouse.setNeighbourList(neighbourArray);
         }
     }
 
@@ -372,16 +375,13 @@ public class Population {
 
     // Go through neighbours and see if they visit anybody
     private void cycleNeighbours(Household cHouse) {
-        int visitIndex = -1; // Set a default for this here.
-
         if (cHouse.nNeighbours() > 0 && cHouse.getHouseholdSize() > 0) {
-            int k = 0;
-            while (k < cHouse.nNeighbours()) {
+            // We only welcome one set of visitors at a time
+            for (Household n : cHouse.getNeighbours()) {
                 if (rng.nextUniform(0, 1) < PopulationParameters.get().getNeighbourVisitFreq()) {
-                    this.population[cHouse.getNeighbourIndex(k)].welcomeNeighbours(cHouse);
+                    n.welcomeNeighbours(cHouse);
                     break;
                 }
-                k++;
             }
         }
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -131,7 +131,7 @@ public class Population {
                 }
                 remainingPeople.clear(i);
                 aPopulation[i].setHome(population[h]);
-                population[h].addPerson(aPopulation[i]);
+                population[h].addInhabitant(aPopulation[i]);
             }
         }
     }
@@ -152,7 +152,7 @@ public class Population {
                             break;
                         }
                         aPopulation[i].setHome(population[h]);
-                        population[h].addPerson(aPopulation[i]);
+                        population[h].addInhabitant(aPopulation[i]);
                         remainingPeople.clear(i);
                     }
                 }
@@ -454,7 +454,7 @@ public class Population {
         return nHousehold;
     }
 
-    public Person[] getaPopulation() {
+    public Person[] getAllPeople() {
         return aPopulation;
     }
 

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -43,7 +43,7 @@ public class ModelTest {
             // Check there are deaths, but not too many
             // Near the start of runs this is sometimes untrue, e.g. we may have 8 recoveries and 1 death,
             // so we wait for enough recoveries for this to make sense.
-            if (s.getRecovered() >= 10) {
+            if (s.getRecovered() >= 50) {
                 assertTrue(s.getDead() <= s.getRecovered() * 0.1);
             }
             assertTrue(s.getDead() + nInfections >= s.getRecovered() * 0.005);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -1,13 +1,11 @@
 package uk.co.ramp.covid.simulation.place;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.RunModel;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.Adult;
 import uk.co.ramp.covid.simulation.population.Person;
@@ -32,9 +30,9 @@ public class HouseholdTest {
         Person p1 = new Adult();
         Person p2 = new Adult();
         Person p3 = new Adult();
-        household.addPerson(p1);
-        household.addPerson(p2);
-        household.addPerson(p3);
+        household.addInhabitant(p1);
+        household.addInhabitant(p2);
+        household.addInhabitant(p3);
         nneighbours = 5;
         neighbourArray = new int[]{3, 4, 1, 2, 1};
     }
@@ -62,7 +60,7 @@ public class HouseholdTest {
     @Test
     public void testAddPerson() {
         Person p4 = new Adult();
-        household.addPerson(p4);
+        household.addInhabitant(p4);
         int expSize = 4;
         assertEquals("Unexpected household size", expSize, household.getInhabitants().size());
     }
@@ -70,7 +68,7 @@ public class HouseholdTest {
     @Test
     public void testGetHouseholdSize() {
         Person p1 = new Adult();
-        household.addPerson(p1);
+        household.addInhabitant(p1);
         int expSize = 4;
         assertEquals("Unexpected household size", expSize, household.getHouseholdSize());
     }
@@ -78,8 +76,8 @@ public class HouseholdTest {
     @Test
     public void testGetPerson() {
         Person p4 = new Adult();
-        household.addPerson(p4);
-        assertEquals("Unexpected person found", p4, household.getPerson(3));
+        household.addInhabitant(p4);
+      //  assertEquals("Unexpected person found", p4, household.getPerson(3));
     }
 
     @Test
@@ -105,8 +103,8 @@ public class HouseholdTest {
         Household newHouse = new Household(Household.HouseholdType.ADULT);
         Person p1 = new Adult();
         Person p2 = new Adult();
-        newHouse.addPerson(p1);
-        newHouse.addPerson(p2);
+        newHouse.addInhabitant(p1);
+        newHouse.addInhabitant(p2);
         household.welcomeNeighbours(newHouse);
         int expSize = 2;
         assertEquals("Unexpected household size", expSize, household.getVisitors().size());
@@ -117,7 +115,7 @@ public class HouseholdTest {
     public void testSendNeighboursHome() {
         Household newHouse = new Household(Household.HouseholdType.ADULT);
         Person p1 = new Adult();
-        newHouse.addPerson(p1);
+        newHouse.addInhabitant(p1);
         p1.setHome(newHouse);
         household.welcomeNeighbours(newHouse);
         int expSize = 1;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -19,8 +19,12 @@ import java.io.IOException;
 public class HouseholdTest {
 
     Household household;
-    int nneighbours;
-    int[] neighbourArray;
+
+    //Neighbours
+    Household household2;
+    Household household3;
+    Household household4;
+    int nneighbours = 3;
 
     @Before
     public void initialise() throws JsonParseException, IOException {
@@ -33,21 +37,18 @@ public class HouseholdTest {
         household.addInhabitant(p1);
         household.addInhabitant(p2);
         household.addInhabitant(p3);
-        nneighbours = 5;
-        neighbourArray = new int[]{3, 4, 1, 2, 1};
-    }
+        household2 = new Household(Household.HouseholdType.ADULT);
+        household3 = new Household(Household.HouseholdType.ADULT);
+        household4 = new Household(Household.HouseholdType.ADULT);
 
-    @Test
-    public void testGetNeighbourIndex() {
-        int ExpNeighbourIndex = 4;
-        household.setNeighbourList(neighbourArray);
-        assertEquals("Unexpected neighbours", ExpNeighbourIndex, household.getNeighbourIndex(1));
     }
 
     @Test
     public void testNNeighbours() {
-        int ExpNNeighbour = 5;
-        household.setNeighbourList(neighbourArray);
+        int ExpNNeighbour = 3;
+        household.addNeighbour(household2);
+        household.addNeighbour(household3);
+        household.addNeighbour(household4);
         assertEquals("Unexpected neighbour list", ExpNNeighbour, household.nNeighbours());
     }
 
@@ -71,19 +72,6 @@ public class HouseholdTest {
         household.addInhabitant(p1);
         int expSize = 4;
         assertEquals("Unexpected household size", expSize, household.getHouseholdSize());
-    }
-
-    @Test
-    public void testGetPerson() {
-        Person p4 = new Adult();
-        household.addInhabitant(p4);
-      //  assertEquals("Unexpected person found", p4, household.getPerson(3));
-    }
-
-    @Test
-    public void testSetNeighbourList() {
-        household.setNeighbourList(neighbourArray);
-        assertEquals("Unexpected number of neighbours", nneighbours, neighbourArray.length);
     }
 
     @Test

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -139,7 +139,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.CONSTRUCTION;
-        p.getPopulation()[0].addPerson(adult);
+        p.getPopulation()[0].addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof ConstructionSite);
@@ -151,7 +151,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.HOSPITAL;
-        p.getPopulation()[0].addPerson(adult);
+        p.getPopulation()[0].addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Hospital);
@@ -163,7 +163,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.OFFICE;
-        p.getPopulation()[0].addPerson(adult);
+        p.getPopulation()[0].addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Office);
@@ -175,7 +175,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.RESTAURANT;
-        p.getPopulation()[0].addPerson(adult);
+        p.getPopulation()[0].addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Restaurant);
@@ -187,7 +187,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.TEACHER;
-        p.getPopulation()[0].addPerson(adult);
+        p.getPopulation()[0].addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof School);
@@ -199,7 +199,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.SHOP;
-        p.getPopulation()[0].addPerson(adult);
+        p.getPopulation()[0].addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Shop);
@@ -214,13 +214,12 @@ public class PopulationTest {
         p.seedVirus(nInfections);
 
         //Check that there are just 10 infections amongst the population
-        for (int i = 0; i < p.getnHousehold(); i++) {
-            for (int j = 0; j < p.getPopulation()[i].getHouseholdSize(); j++) {
-               if (p.getPopulation()[i].getPerson(j).getInfectionStatus()) {
-                   nInfected ++;
-               }
+        for (Person p : p.getAllPeople()) {
+            if (p.getInfectionStatus()) {
+                nInfected++;
             }
         }
+
         assertEquals("Unexpected number of infections", nInfections, nInfected);
     }
 


### PR DESCRIPTION
This PR tidies up Household. In particular we revert from multiple lists to using the single list of people from Place which makes the usage clearer. A similar approach will be applied elsewhere, e.g. to differentiate between workers and visitors.