### PR TITLE
Use simulationID in output csv file and RNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,16 @@ gradle build
 
 ## Running a Simulation
 
-The built java project takes two positional commandline arguments. The first is
-a json file defining the disease and population parameters, and the second is a
-json file defining the parameters of a particular run, for example, the number
-of iterations. Example json files and further documentation are provided in the
-`parameters` folder.
+The built java project takes three positional commandline arguments. The first is
+a json file defining the disease and population parameters, the second is a
+json file defining parameters of a particular run, and the third is the simulation
+number for HPC array runs (which should be 0 for single runs). Example json files
+and further documentation are provided in the `parameters` folder.
 
 To run the project:
 ```shell script
-gradle run  --args "parameters/example_population_params.json parameters/example_model_params.json"
+gradle run  --args "parameters/example_population_params.json parameters/example_model_params.json 0"
 ```
-
-The run command optionally takes an integer to be used as the seed for the
-random number generator (such that two identically seeded runs will return the
-same result).
 
 The result csv will be placed into the file specified by the `outputFile` parameter
 in the model parameters.

--- a/parameters/ModelParameters.md
+++ b/parameters/ModelParameters.md
@@ -11,7 +11,7 @@ An example parameters file is in `example_model_params.json`
 | nDays          | Number of days to simulate                       | Int          |
 | nIters         | Number of simulation iterations                  | Int          |
 | outputFile     | Name/location of output csv file                 | String       |
-| rngSeed        | Daily probability an adult progresses to Phase 2 | Optional Int |
+| rngSeed        | Seed for random number generation                | Int          |
 
 ## Lockdowns 
 

--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -11,12 +11,10 @@ import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;
 import uk.co.ramp.covid.simulation.util.RNG;
 
-
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
-import java.lang.reflect.Field;
 import java.util.*;
 
 /** A uk.co.ramp.covid.simulation.Model represents a particular run of the model with some given parameters
@@ -140,6 +138,10 @@ public class Model {
             LOGGER.warn("Uninitialised model parameter: nDays");
             valid = false;
         }
+        if (rngSeed == null) {
+            LOGGER.warn("Uninitialised model parameter: rngSeed");
+            valid = false;
+        }
         if (!outputDisabled) {
             if (outputFile == null) {
                 LOGGER.warn("Uninitialised model parameter: outputFile");
@@ -164,17 +166,12 @@ public class Model {
     }
 
     /** Runs the model with the given parameters. Returns null if the parameters are missing or invalid */
-    public List<List<DailyStats>> run() {
+    public List<List<DailyStats>> run(int simulationID) {
         if (!isValid()) {
             throw new InvalidParametersException("Invalid model parameters");
         }
 
-
-        if (rngSeed != null) {
-            RNG.seed(rngSeed);
-        } else {
-            LOGGER.warn("No RNG seed given. Proceeding with random seed");
-        }
+        RNG.seed(rngSeed + simulationID);
 
         List<List<DailyStats>> stats = new ArrayList<>(nIters);
         for (int i = 0; i < nIters; i++) {
@@ -206,14 +203,14 @@ public class Model {
 
         if (!outputDisabled) {
             if (outputFile != null) {
-                outputCSV(stats);
+                outputCSV(simulationID, stats);
             }
         }
 
         return stats;
     }
 
-    public void outputCSV(List<List<DailyStats>> stats) {
+    public void outputCSV(int startIterID, List<List<DailyStats>> stats) {
     final String[] headers = {"iter", "day", "H", "L", "A", "P1", "P2", "D", "R",
                               "ICs", "IHos","INur","IOff","IRes","ISch","ISho","IHome",
                               "IAdu","IPen","IChi","Iinf",
@@ -223,7 +220,7 @@ public class Model {
             CSVPrinter printer = new CSVPrinter(out, CSVFormat.DEFAULT.withHeader(headers));
             for (int i = 0; i < nIters; i++) {
                 for (DailyStats s : stats.get(i)) {
-                    s.appendCSV(printer, i);
+                    s.appendCSV(printer, startIterID + i);
                 }
             }
             out.close();

--- a/src/main/java/uk/co/ramp/covid/simulation/RunModel.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/RunModel.java
@@ -7,30 +7,26 @@
 package uk.co.ramp.covid.simulation;
 
 import com.google.gson.JsonParseException;
-import org.apache.commons.math3.random.RandomDataGenerator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
-import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
-import java.io.FileWriter;
 import java.io.IOException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 
 public class RunModel {
     private static final Logger LOGGER = LogManager.getLogger(RunModel.class);
 
     public static void main(String[] args) throws Exception {
-        if (args.length < 2) {
-            LOGGER.error("Expected parameters: <population_params.json> <model_params.json> [rngseed]");
+        if (args.length != 3) {
+            LOGGER.error("Expected parameters: <population_params.json> <model_params.json> <simulationID>");
             System.exit(-1);
         } else {
-            readParameters(args[0]);
+            String populationParamsFile = args[0];
+            String modelParamsFile = args[1];
+            int simulationID = Integer.parseInt(args[2]);
+            
+            readParameters(populationParamsFile);
 
             if (!PopulationParameters.get().isValid()) {
                 LOGGER.error("Could not read population parameters");
@@ -42,17 +38,13 @@ public class RunModel {
                 System.exit(-2);
             }
 
-            Model m  = Model.readModelFromFile(args[1]);
-
-            if (args.length == 3) {
-                m.setRNGSeed(Integer.parseInt(args[2]));
-            }
+            Model m  = Model.readModelFromFile(modelParamsFile);
 
             if (!m.isValid()) {
                 LOGGER.error("Could not read model parameters");
                 System.exit(-2);
             } else {
-                m.run();
+                m.run(simulationID);
             }
         }
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/util/RNG.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/RNG.java
@@ -5,21 +5,21 @@ import org.apache.commons.math3.random.RandomDataGenerator;
 /** Singleton for managing random number generation */
 public class RNG {
     private static RandomDataGenerator rng = null;
-    private static int currentSeed;
 
     private RNG () {};
 
     public static RandomDataGenerator get() {
         if (rng == null) {
             rng = new RandomDataGenerator();
+
+            // Use a fixed seed for tests
+            // - seed() will always be called to override this in non-test runs  
+            rng.reSeed(0);
         }
         return rng;
     }
 
     public static void seed(int seed) {
         get().reSeed(seed);
-        currentSeed = seed;
     }
-
-    public static int getCurrentSeed() { return currentSeed; }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/CovidTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/CovidTest.java
@@ -17,6 +17,7 @@ public class CovidTest {
     //Test that a pensioner steps through the infection from latent to death
     @Test
     public void testStepInfectionSymptomatic() throws IOException {
+        RNG.seed(1); // This test is sensitive to random numbers
         //Use the test file with a mortality rate of 100
         ParameterReader.readParametersFromFile("src/test/resources/test_params.json");
         CStatus cStatus = null;

--- a/src/test/java/uk/co/ramp/covid/simulation/CovidTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/CovidTest.java
@@ -15,7 +15,6 @@ public class CovidTest {
     //Test that a pensioner steps through the infection from latent to death
     @Test
     public void testStepInfection() throws IOException {
-        RNG.seed(321);
         //Use the test file with a mortality rate of 100
         ParameterReader.readParametersFromFile("src/test/resources/test_params.json");
         CStatus cStatus = null;
@@ -51,7 +50,6 @@ public class CovidTest {
     //Test that a child steps through the infection from latent to recovered
     @Test
     public void testStepInfectionRecover() throws IOException {
-        RNG.seed(321);
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         CStatus cStatus = null;
         Person child = new Child();

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -2,12 +2,13 @@ package uk.co.ramp.covid.simulation;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Assert;
+
+import com.google.gson.JsonParseException;
+
 import uk.co.ramp.covid.simulation.io.ParameterReader;
+import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -34,7 +35,7 @@ public class ModelTest {
                 .setRNGSeed(42)
                 .setNoOutput();
 
-        List<List<DailyStats>> stats = m.run();
+        List<List<DailyStats>> stats = m.run(0);
 
         int lastTotalInfected = 10;
         for (DailyStats s : stats.get(0)) {
@@ -95,7 +96,7 @@ public class ModelTest {
                 .setRNGSeed(seed)
                 .setNoOutput();
 
-        List<List<DailyStats>> run1res = run1.run();
+        List<List<DailyStats>> run1res = run1.run(0);
 
         Model run2 = new Model()
                 .setPopulationSize(population)
@@ -106,7 +107,7 @@ public class ModelTest {
                 .setRNGSeed(seed)
                 .setNoOutput();
 
-        List<List<DailyStats>> run2res = run2.run();
+        List<List<DailyStats>> run2res = run2.run(0);
 
         assertEquals(run1res.size(), run2res.size());
         assertEquals(run1res.get(0).size(), run2res.get(0).size());
@@ -116,5 +117,13 @@ public class ModelTest {
         for (int i = 0; i < r1.size(); i++) {
             assertEquals(r1.get(i), r2.get(i));
         }
+    }
+    
+    @Test
+    public void testReadModelFromFile() throws JsonParseException, IOException {
+        Model m  = Model.readModelFromFile("src/test/resources/test_model_params.json");
+        m.setNoOutput();
+        assertTrue(m.isValid());
+        m.run(0);
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
@@ -23,7 +23,6 @@ public class ConstructionSiteTest {
 
     @Test
     public void testConstructionSiteTransProb() throws JsonParseException, IOException {
-        RNG.seed(123);
         ConstructionSite constructionSite = new ConstructionSite();
         double expProb = PopulationParameters.get().getpBaseTrans() * 10d / (5000d / 100d);
         double delta = 0.01;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -23,7 +23,6 @@ public class HospitalTest {
 
     @Test
     public void testHospitalTransProb() throws JsonParseException, IOException {
-        RNG.seed(123);
         Hospital hospital = new Hospital();
         double expProb = PopulationParameters.get().getpBaseTrans() * 15d / (5000d / 10d);
         double delta = 0.01;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -100,6 +100,7 @@ public class HouseholdTest {
     
     @Test
     public void testSendNeighboursHome() {
+        RNG.seed(3); // This test is very sensitive to random numbers
         Household newHouse = new Household(Household.HouseholdType.ADULT);
         Person p1 = new Adult();
         newHouse.addInhabitant(p1);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -27,7 +27,6 @@ public class HouseholdTest {
     @Before
     public void initialise() throws JsonParseException, IOException {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-        RNG.seed(123);
         household = new Household(Household.HouseholdType.ADULT);
         Person p1 = new Adult();
         Person p2 = new Adult();

--- a/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
@@ -23,7 +23,6 @@ public class NurseryTest {
 
     @Test
     public void testNurseryTransProb() throws JsonParseException, IOException {
-        RNG.seed(123);
         Nursery nursery = new Nursery();
         double expProb = PopulationParameters.get().getpBaseTrans() * 30d / (34000d / 50d);
         double delta = 0.01;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
@@ -23,7 +23,6 @@ public class OfficeTest {
 
     @Test
     public void testOfficeTransProb() throws JsonParseException, IOException {
-        RNG.seed(123);
         Office office = new Office();
         double expProb = PopulationParameters.get().getpBaseTrans() * 10d / (10000d / 400d);
         double delta = 0.01;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -25,7 +25,6 @@ public class RestaurantTest {
     public void initialise() throws JsonParseException, IOException {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
 
-        RNG.seed(123);
         //Setup a restaurant with 2 people
         restaurant = new Restaurant();
         p1 = new Adult();

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -21,7 +21,6 @@ public class SchoolTest {
 
     @Test
     public void testSchoolTransProb() {
-        RNG.seed(123);
         School school = new School();
         double expProb = PopulationParameters.get().getpBaseTrans() * 30d / (34000d / 50d);
         double delta = 0.01;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -24,7 +24,6 @@ public class ShopTest {
     @Before
     public void initialise() throws JsonParseException, IOException {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-        RNG.seed(123);
         //Setup a shop with 2 people
         shop = new Shop();
         p1 = new Adult();

--- a/src/test/java/uk/co/ramp/covid/simulation/population/AdultTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/AdultTest.java
@@ -13,7 +13,6 @@ public class AdultTest {
     public void testSetProfession() throws JsonParseException, IOException {
         //Test that a profession is set for an adult
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-        RNG.seed(123);
         Adult adult = new Adult();
         adult.setProfession();
         boolean professionSet = false;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
@@ -15,7 +15,6 @@ public class ChildTest {
     @Test
     public void testChildAtSchool() throws JsonParseException, IOException {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-        RNG.seed(123);
         Population p = new Population(5000,600);
         try {
             p.populateHouseholds();

--- a/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
@@ -15,7 +15,6 @@ public class InfantTest {
     @Test
     public void testInfant() throws JsonParseException, IOException {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-        RNG.seed(100);
         int nNursery = 0;
         //Test 50% of infants go to nursery
         for (int i = 0; i < 1000; i++) {
@@ -29,7 +28,6 @@ public class InfantTest {
     public void testInfantReports() throws IOException {
         //Test Infant methods reportInfection() and reportDeath()
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-        RNG.seed(123);
         Population p = new Population(500,60);
         try {
             p.populateHouseholds();

--- a/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
@@ -14,6 +14,7 @@ public class InfantTest {
 
     @Test
     public void testInfant() throws JsonParseException, IOException {
+        RNG.seed(0); // This test is sensitive to random numbers
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         int nNursery = 0;
         //Test 50% of infants go to nursery

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
@@ -17,7 +17,6 @@ public class PensionerTest {
     public void testPensionerReports() throws IOException {
         //Test Pensioner methods reportInfection() and reportDeath()
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-        RNG.seed(123);
         Population p = new Population(500,60);
         try {
             p.populateHouseholds();

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PersonTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PersonTest.java
@@ -13,7 +13,6 @@ public class PersonTest {
     @Before
     public void initialise() throws JsonParseException, IOException {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-        RNG.seed(123);
     }
 
     @Test

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
@@ -19,8 +19,7 @@ public class PlacesTest {
     @Before
     public void setupParams() throws IOException {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-        // NOTE: This test is no guarenteed to pass with a different seed due to randomness
-        RNG.seed(42);
+        // NOTE: This test is not guaranteed to pass with a different seed due to randomness
     }
 
 

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -22,7 +22,6 @@ public class PopulationTest {
     public void setupParams() throws IOException {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         populationSize = 10000;
-        RNG.seed(123);
         p = new Population(populationSize,1000);
         try {
             p.populateHouseholds();

--- a/src/test/resources/test_model_params.json
+++ b/src/test/resources/test_model_params.json
@@ -1,0 +1,9 @@
+{
+    "populationSize":10000,
+    "nHouseholds":3000,
+    "nInfections":10,
+    "nDays":10,
+    "nIters":1,
+    "rngSeed":42,
+    "outputFile":"./example.csv"
+}


### PR DESCRIPTION
Add simulationID to the iter ID in the output csv file.  Use the RNG seed value from the file together with the simulationID from command line to seed the RNG.  Make the third command line parameter and rngSeed model parameter compulsory (to simplify things), and set a default fixed RNG seed for use in tests (so that all the tests don't have to explicitly seed the RNG).