### PR TITLE
Overhaul Movement and Add Shifts

### DIFF
--- a/parameters/PopulationParameters.md
+++ b/parameters/PopulationParameters.md
@@ -65,6 +65,7 @@ Distribution should add to 1.
 | pConstruction   | Probability of working in construction                                  | Double |
 | pTeacher        | Probability of being a teacher                                          | Double |
 | pRestaurant     | Probability of working in a restaurant                                  | Double |
+| pNursery        | Probability of working in a nursery                                     | Double |
 | pUnemployed     | Probability of being unemployed                                         | Double |
 | allocationSizes | Probability of being assigned to work in a large/medium/small workplace | Double |
 

--- a/parameters/PopulationParameters.md
+++ b/parameters/PopulationParameters.md
@@ -94,14 +94,16 @@ households may include either/both children or infants.
 
 -   Object name: `households`
 
-| Parameter Name          | Description                                       | Type   |
-|-------------------------|---------------------------------------------------|--------|
-| pAdultOnly              | Probability of an adult only household            | Double |
-| pPensionerOnly          | Probability of a pensioner only household         | Double |
-| pPensionerAdult         | Probability of an adult/pensioner household       | Double |
-| AdultChildren           | Probability of an adult/child household           | Double |
-| pPnsionerChildren       | Probability of an pensioner/child household       | Double |
-| pAdultPensionerChildren | Probability of an adult/pensioner/child household | Double |
+| Parameter Name          | Description                                                       | Type   |
+|-------------------------|-------------------------------------------------------------------|--------|
+| pAdultOnly              | Probability of an adult only household                            | Double |
+| pPensionerOnly          | Probability of a pensioner only household                         | Double |
+| pPensionerAdult         | Probability of an adult/pensioner household                       | Double |
+| AdultChildren           | Probability of an adult/child household                           | Double |
+| pPnsionerChildren       | Probability of an pensioner/child household                       | Double |
+| pAdultPensionerChildren | Probability of an adult/pensioner/child household                 | Double |
+| pGoShopping             | Probability the households tries to go shopping in an hour        | Double |
+| pGoRestaurant           | Probability the households tries to go to a restaurant in an hour | Double |
 
 ## Household Size Distributions
 
@@ -174,17 +176,19 @@ an essential service).
 
 -   Object name: `buildingProperties`
 
-| Parameter Name         | Description                                             | Type   |
-|------------------------|---------------------------------------------------------|--------|
-| pBaseTrans             | Base disease transmission probability for all places    | Double |
-| pHospitalTrans         | Disease transmission probability in a hospital          | Double |
-| pConstructionSiteTrans | Disease transmission probability on a construction site | Double |
-| pNurseryTrans          | Disease transmission probability in a nursery           | Double |
-| pOfficeTrans           | Disease transmission probability in an office           | Double |
-| pRestaurantTrans       | Disease transmission probability in a restaurant        | Double |
-| pSchoolTrans           | Disease transmission probability in a school            | Double |
-| pShopTrans             | Disease transmission probability in a shop              | Double |
-| pHospitalKey           | Probability a hospital closes in a lockdown             | Double |
-| pConstructionSiteKey   | Probability a construction site closes in a lockdown    | Double |
-| pOfficeKey             | Probability an office closes in a lockdown              | Double |
-| pShopKey               | Probability a shop closes in a lockdown                 | Double |
+| Parameter Name         | Description                                                    | Type   |
+|------------------------|----------------------------------------------------------------|--------|
+| pBaseTrans             | Base disease transmission probability for all places           | Double |
+| pHospitalTrans         | Disease transmission probability in a hospital                 | Double |
+| pConstructionSiteTrans | Disease transmission probability on a construction site        | Double |
+| pNurseryTrans          | Disease transmission probability in a nursery                  | Double |
+| pOfficeTrans           | Disease transmission probability in an office                  | Double |
+| pRestaurantTrans       | Disease transmission probability in a restaurant               | Double |
+| pSchoolTrans           | Disease transmission probability in a school                   | Double |
+| pShopTrans             | Disease transmission probability in a shop                     | Double |
+| pHospitalKey           | Probability a hospital closes in a lockdown                    | Double |
+| pConstructionSiteKey   | Probability a construction site closes in a lockdown           | Double |
+| pOfficeKey             | Probability an office closes in a lockdown                     | Double |
+| pShopKey               | Probability a shop closes in a lockdown                        | Double |
+| pLeaveShop             | Probability a shopper decides to leave a shop in an hour       | Double |
+| pLeaveRestaurant       | Probability a shopper decides to leave a restaurant in an hour | Double |

--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -130,7 +130,9 @@
             "pHospitalKey":0.8,
             "pConstructionSiteKey":0.5,
             "pOfficeKey":0.5,
-            "pShopKey":0.5
+            "pShopKey":0.5,
+            "pLeaveShop": 0.5,
+            "pLeaveRestaurant": 0.4
         },
         "infantAllocation":{
             "pAttendsNursery":0.5
@@ -138,7 +140,9 @@
         "householdProperties":{
             "neighbourVisitFreq":0.006,
             "visitorLeaveRate":0.5,
-            "expectedNeighbours":3
+            "expectedNeighbours":3,
+            "pGoShopping":0.01786,
+            "pGoRestaurant": 0.01190
         },
         "personProperties":{
             "pTransmission":0.45,

--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -114,8 +114,9 @@
             "pShop":0.1,
             "pHospital":0.1,
             "pConstruction":0.1,
-            "pTeacher":0.2,
+            "pTeacher":0.15,
             "pRestaurant":0.1,
+            "pNursery":0.05,
             "pUnemployed":0.2,
             "sizeAllocation":{
                 "pSmall": 0.2,

--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -16,7 +16,6 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
-import java.lang.reflect.Field;
 import java.util.*;
 
 /** A uk.co.ramp.covid.simulation.Model represents a particular run of the model with some given parameters
@@ -201,7 +200,7 @@ public class Model {
             if (schoolLockDown != null) {
                 p.setSchoolLockdown(schoolLockDown.start, schoolLockDown.end, schoolLockDown.socialDistance);
             }
-            stats.add(p.timeStep(nDays));
+            stats.add(p.simulate(nDays));
         }
 
         if (!outputDisabled) {

--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -190,7 +190,6 @@ public class Model {
                 break;
             }
 
-            p.summarisePop();
             p.createMixing();
             p.allocatePeople();
             p.seedVirus(nInfections);

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -37,6 +37,7 @@ public abstract class CommunalPlace extends Place {
         size = s;
     }
 
+
     public CommunalPlace() {
         super();
         this.rng = RNG.get();
@@ -74,8 +75,18 @@ public abstract class CommunalPlace extends Place {
     }
     
     public boolean isVisitorOpenNextHour(int day, int hour) {
-        return hour + 1 >= times.getVisitorOpen() 
+        return  times.getOpenDays().get(day)
+                && hour + 1 >= times.getVisitorOpen()
                 && hour + 1 < times.getVisitorClose();
+    }
+
+    public boolean isOpen(int day, int hour) {
+        if (!times.getOpenDays().get(day)) {
+            return false;
+        }
+
+        return hour >= times.getOpen()
+                && hour < times.getClose();
     }
 
     public List<Person> getStaff(int day, int hour) {
@@ -88,6 +99,7 @@ public abstract class CommunalPlace extends Place {
         }
         return res;
     }
+
     @Override
     public void doMovement(int day, int hour, boolean lockdown) {
         moveShifts(day, hour, lockdown);

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -26,6 +26,8 @@ public abstract class CommunalPlace extends Place {
     protected boolean keyPremises;
     protected double keyProb;
 
+    protected int nStaff = 0;
+
     protected final RandomDataGenerator rng;
     
     public abstract Shifts getShifts();
@@ -76,6 +78,16 @@ public abstract class CommunalPlace extends Place {
                 && hour + 1 < times.getVisitorClose();
     }
 
+    public List<Person> getStaff(int day, int hour) {
+        List<Person> res = new ArrayList<>();
+        for (Person p : people) {
+            if (p.getPrimaryCommunalPlace() == this
+                    && p.worksNextHour(this, day, hour - 1, false)) {
+                res.add(p);
+            }
+        }
+        return res;
+    }
     @Override
     public void doMovement(int day, int hour, boolean lockdown) {
         moveShifts(day, hour, lockdown);
@@ -84,4 +96,10 @@ public abstract class CommunalPlace extends Place {
     public boolean isKeyPremises() {
         return keyPremises;
     }
+
+    public int getnStaff() {
+        return nStaff;
+    }
+    
+    public abstract boolean isFullyStaffed();
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -17,8 +17,6 @@ import java.util.List;
 
 public abstract class CommunalPlace extends Place {
 
-    private static final Logger LOGGER = LogManager.getLogger(CommunalPlace.class);
-
     public enum Size {
         SMALL, MED, LARGE, UNKNOWN
     }
@@ -48,31 +46,6 @@ public abstract class CommunalPlace extends Place {
 
     public void overrideKeyPremises(boolean overR) {
         this.keyPremises = overR;
-    }
-
-    // Check whether a Person might visit at that hour of the day
-    public boolean checkVisit(Person cPers, int time, int day, boolean clockdown) {
-        boolean cIn = false;
-        if (times.isOpen(time, day) && (this.keyPremises || !clockdown)) {
-            cIn = true;
-            people.add(cPers);
-        }
-        return cIn;
-    }
-
-    // Cycle through the People objects in the Place and test their infection status etc
-    public void cyclePlace(int time, int day, DailyStats stats) {
-        doInfect(stats);
-
-        List<Person> left = new ArrayList<>();
-        for (Person cPers : people) {
-            if (!times.isOpen(time, day)) {
-                cPers.returnHome();
-                left.add(cPers);
-            }
-        }
-
-        people.removeAll(left);
     }
 
     public void adjustSDist(double sVal) {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -8,11 +8,7 @@ import org.apache.commons.math3.random.RandomDataGenerator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.RunModel;
-import uk.co.ramp.covid.simulation.population.CStatus;
-import uk.co.ramp.covid.simulation.population.Pensioner;
 import uk.co.ramp.covid.simulation.population.Person;
-import uk.co.ramp.covid.simulation.population.PopulationParameters;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.util.ArrayList;
@@ -27,11 +23,7 @@ public abstract class CommunalPlace extends Place {
     }
     
     protected Size size;
-
-    protected int startTime;
-    protected int endTime;
-    protected int startDay;
-    protected int endDay;
+    protected OpeningTimes times;
     protected boolean keyPremises;
     protected double keyProb;
 
@@ -45,13 +37,10 @@ public abstract class CommunalPlace extends Place {
     public CommunalPlace() {
         super();
         this.rng = RNG.get();
-        this.startTime = 8; // The hour of the day that the Communal Place starts
-        this.endTime = 17; // The hour of the day that it ends
-        this.startDay = 1; // Days of the week that it is active - start
-        this.endDay = 5; // Days of the week that it is active - end
+        this.times = new OpeningTimes(8,17,1,5, OpeningTimes.getAllDays());
+
         this.keyProb = 1.0;
         if (rng.nextUniform(0, 1) > this.keyProb) this.keyPremises = true;
-
     }
 
     public void overrideKeyPremises(boolean overR) {
@@ -61,7 +50,7 @@ public abstract class CommunalPlace extends Place {
     // Check whether a Person might visit at that hour of the day
     public boolean checkVisit(Person cPers, int time, int day, boolean clockdown) {
         boolean cIn = false;
-        if (this.startTime == time && day >= this.startDay && day <= this.endDay && (this.keyPremises || !clockdown)) {
+        if (times.isOpen(time, day) && (this.keyPremises || !clockdown)) {
             cIn = true;
             people.add(cPers);
         }
@@ -69,12 +58,12 @@ public abstract class CommunalPlace extends Place {
     }
 
     // Cycle through the People objects in the Place and test their infection status etc
-    public void cyclePlace(int time, DailyStats stats) {
+    public void cyclePlace(int time, int day, DailyStats stats) {
         doInfect(stats);
 
         List<Person> left = new ArrayList<>();
         for (Person cPers : people) {
-            if (time == endTime) {
+            if (!times.isOpen(time, day)) {
                 cPers.returnHome();
                 left.add(cPers);
             }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -83,4 +83,20 @@ public abstract class CommunalPlace extends Place {
         size = s;
     }
 
+    /** Move everyone based on their shift patterns */
+    public void moveShifts(int day, int hour) {
+        List<Person> left = new ArrayList();
+        for (Person p : people) {
+            if (!p.worksNextHour(this, day, hour)) {
+                p.returnHome();
+            }
+        }
+        people.removeAll(left);
+    }
+    
+    public boolean isVisitorOpenNextHour(int day, int hour) {
+        return hour + 1 >= times.getVisitorOpen() 
+                && hour + 1 < times.getVisitorClose();
+    }
+
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.Person;
+import uk.co.ramp.covid.simulation.population.Shifts;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.util.ArrayList;
@@ -28,6 +29,8 @@ public abstract class CommunalPlace extends Place {
     protected double keyProb;
 
     protected final RandomDataGenerator rng;
+    
+    public abstract Shifts getShifts();
 
     public CommunalPlace(Size s) {
         this();
@@ -104,7 +107,7 @@ public abstract class CommunalPlace extends Place {
     public void doMovement(int day, int hour, boolean lockdown) {
         moveShifts(day, hour, lockdown);
     }
-
+    
     public boolean isKeyPremises() {
         return keyPremises;
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -84,10 +84,10 @@ public abstract class CommunalPlace extends Place {
     }
 
     /** Move everyone based on their shift patterns */
-    public void moveShifts(int day, int hour) {
+    public void moveShifts(int day, int hour, boolean lockdown) {
         List<Person> left = new ArrayList();
         for (Person p : people) {
-            if (!p.worksNextHour(this, day, hour)) {
+            if (!p.worksNextHour(this, day, hour, lockdown)) {
                 p.returnHome();
                 left.add(p);
             }
@@ -101,7 +101,9 @@ public abstract class CommunalPlace extends Place {
     }
 
     @Override
-    public void doMovement(int day, int hour) {
-        moveShifts(day, hour);
+    public void doMovement(int day, int hour, boolean lockdown) {
+        moveShifts(day, hour, lockdown);
     }
+
+    public boolean isKeyPremises() { return keyPremises; }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -89,6 +89,7 @@ public abstract class CommunalPlace extends Place {
         for (Person p : people) {
             if (!p.worksNextHour(this, day, hour)) {
                 p.returnHome();
+                left.add(p);
             }
         }
         people.removeAll(left);
@@ -99,4 +100,8 @@ public abstract class CommunalPlace extends Place {
                 && hour + 1 < times.getVisitorClose();
     }
 
+    @Override
+    public void doMovement(int day, int hour) {
+        moveShifts(day, hour);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
@@ -2,6 +2,7 @@ package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
+import uk.co.ramp.covid.simulation.population.Shifts;
 
 public class ConstructionSite extends CommunalPlace {
 
@@ -14,12 +15,17 @@ public class ConstructionSite extends CommunalPlace {
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpConstructionSiteTrans();
         keyProb = PopulationParameters.get().getpConstructionSiteKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;
-
+        times = OpeningTimes.nineFiveWeekdays();
     }
 
     @Override
     public void reportInfection(DailyStats s) {
         s.incInfectionConstructionSite();
+    }
+
+    @Override
+    public Shifts getShifts() {
+        return Shifts.nineFiveFiveDays();
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
@@ -22,10 +22,4 @@ public class ConstructionSite extends CommunalPlace {
         s.incInfectionConstructionSite();
     }
 
-    @Override
-    public void doMovement(int day, int hour) {
-        moveShifts(day, hour);
-    }
-
-
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
@@ -25,7 +25,13 @@ public class ConstructionSite extends CommunalPlace {
 
     @Override
     public Shifts getShifts() {
+        nStaff++;
         return Shifts.nineFiveFiveDays();
+    }
+
+    @Override
+    public boolean isFullyStaffed() {
+        return nStaff > 0;
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
@@ -22,6 +22,10 @@ public class ConstructionSite extends CommunalPlace {
         s.incInfectionConstructionSite();
     }
 
+    @Override
+    public void doMovement(int day, int hour) {
+        moveShifts(day, hour);
+    }
 
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -20,9 +20,4 @@ public class Hospital extends CommunalPlace {
     public void reportInfection(DailyStats s) {
         s.incInfectionHospital();
     }
-
-    @Override
-    public void doMovement(int day, int hour) {
-        moveShifts(day, hour);
-    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -32,7 +32,13 @@ public class Hospital extends CommunalPlace {
 
     @Override
     public Shifts getShifts() {
+        nStaff++;
         return shifts.getNext();
+    }
+
+    @Override
+    public boolean isFullyStaffed() {
+        return nStaff >= 4;
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -20,4 +20,9 @@ public class Hospital extends CommunalPlace {
     public void reportInfection(DailyStats s) {
         s.incInfectionHospital();
     }
+
+    @Override
+    public void doMovement(int day, int hour) {
+        moveShifts(day, hour);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -12,8 +12,6 @@ public class Hospital extends CommunalPlace {
     public Hospital(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpHospitalTrans();
-        startDay = 3; //Bodge set start day to a different day of the week to help syncing
-        endDay = 7;
         keyProb = PopulationParameters.get().getpHospitalKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -2,8 +2,12 @@ package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
+import uk.co.ramp.covid.simulation.population.Shifts;
+import uk.co.ramp.covid.simulation.util.RoundRobinAllocator;
 
 public class Hospital extends CommunalPlace {
+    
+    private RoundRobinAllocator<Shifts> shifts;
 
     public Hospital() {
         this(Size.UNKNOWN);
@@ -13,7 +17,22 @@ public class Hospital extends CommunalPlace {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpHospitalTrans();
         keyProb = PopulationParameters.get().getpHospitalKey();
+        times = OpeningTimes.twentyfourSeven();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;
+        allocateShifts();
+    }
+
+    private void allocateShifts() {
+        shifts = new RoundRobinAllocator<>();
+        shifts.put(new Shifts(0,12, 0, 1, 2));
+        shifts.put(new Shifts(12,0, 0, 1, 2));
+        shifts.put(new Shifts(0,12, 3, 4, 5, 6));
+        shifts.put(new Shifts(12,0, 3, 4, 5, 6));
+    }
+
+    @Override
+    public Shifts getShifts() {
+        return shifts.getNext();
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -222,8 +222,7 @@ public class Household extends Place {
     private void moveShop(int day, int hour) {
         List<Person> left = new ArrayList();
 
-        //TODO: Make these parameters
-        double visitProb = 3.0 / 7.0 / 24.0; // Based on three visits per week to shops
+        double visitProb = PopulationParameters.get().getpGoShopping();
         //TODO: Handle lockdown probabilities
 
         if (RNG.get().nextUniform(0, 1) < visitProb) {
@@ -249,8 +248,7 @@ public class Household extends Place {
     private void moveRestaurant(int day, int hour) {
         List<Person> left = new ArrayList();
 
-        // TODO: Make this a parameter
-        double visitProb = 2.0 / 7.0 / 24.0;
+        double visitProb = PopulationParameters.get().getpGoRestaurant();
         //TODO: Handle lockdown probabilities
 
         if (RNG.get().nextUniform(0, 1) < visitProb) {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -113,13 +113,20 @@ public class Household extends Place {
         ArrayList<Person> left = new ArrayList<>();
 
         for (Person p : getVisitors()) {
+            // People may have already left if their family has
+            if (left.contains(p)) {
+                continue;
+            }
+
             // Under certain conditions we must go home, e.g. if there is a shift starting soon
             if (p.mustGoHome(day, hour)) {
                 left.add(p);
                 p.returnHome();
+                left.addAll(sendFamilyHome(p));
             }
             else if (RNG.get().nextUniform(0, 1) < PopulationParameters.get().getHouseholdVisitorLeaveRate()) {
                 left.add(p);
+                left.addAll(sendFamilyHome(p));
                 if (p.cStatus() != CStatus.DEAD) {
                    p.returnHome();
                 }
@@ -273,7 +280,7 @@ public class Household extends Place {
             if (r == null) {
                 return;
             }
-            
+
             int retries = 5;
             while (!r.isVisitorOpenNextHour(day, hour)) {
                 r = places.getRandomRestaurant();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -77,38 +77,6 @@ public class Household extends Place {
         return cPers.infect();
     }
 
-    // Go through the household at each time step and see what they get up to
-    public List<Person> cycleHouse(DailyStats stats) {
-        doInfect(stats);
-        return people;
-    }
-
-    private ArrayList<Person> neighbourVisit() {
-        ArrayList<Person> visitPeople = new ArrayList<>();
-
-        for (Person p : getInhabitants()) {
-            if (!p.getQuarantine()) {
-                visitPeople.add(p);
-            }
-        }
-
-        if (visitPeople.size() == 0) {
-            return null;
-        }
-
-        people.removeAll(visitPeople);
-
-        return visitPeople;
-    }
-
-    // Neighbours go into a List of their own - we don't copy the list whole because the way multiple neighbour visits can happen concurrently
-    public void welcomeNeighbours(Household visitHouse) {
-        ArrayList<Person> visitVector = visitHouse.neighbourVisit();
-        if (visitVector != null) {
-            this.people.addAll(visitVector);
-        }
-    }
-
     public int sendNeighboursHome(int day, int hour) {
         ArrayList<Person> left = new ArrayList<>();
 
@@ -135,20 +103,6 @@ public class Household extends Place {
 
         people.removeAll(left);
         return left.size();
-    }
-
-    // Get a vector of people to go to the shops.
-    public ArrayList<Person> shoppingTrip() {
-        ArrayList<Person> shopping = new ArrayList<>();
-
-        for (Person p : getInhabitants()) {
-            if (!p.getQuarantine()) {
-                shopping.add(p);
-            }
-        }
-        people.removeAll(shopping);
-
-        return shopping;
     }
     
     private boolean isVisitor(Person p) {
@@ -178,20 +132,6 @@ public class Household extends Place {
     @Override
     public void reportInfection(DailyStats s) {
         s.incInfectionsHome();
-    }
-
-    // For each household processes any movements to Communal Places that are relevant
-    public void cycleMovements(int day, int hour, boolean lockdown) {
-        List<Person> left = new ArrayList<>();
-        for (Person p : getInhabitants()) {
-            if (p.hasPrimaryCommunalPlace() && !p.getQuarantine()) {
-                boolean visit = p.getPrimaryCommunalPlace().checkVisit(p, hour, day, lockdown);
-                if (visit) {
-                    left.add(p);
-                }
-            }
-        }
-        people.removeAll(left);
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -188,15 +188,17 @@ public class Household extends Place {
     }
 
     @Override
-    public void doMovement(int day, int hour) {
-       moveShift(day, hour);
+    public void doMovement(int day, int hour, boolean lockdown) {
+       moveShift(day, hour, lockdown);
 
        // Implies shopping trips have higher priority than neighbour and restaurant trips
-       moveShop(day, hour);
+       moveShop(day, hour, lockdown);
 
        moveNeighbour(day, hour);
-       moveRestaurant(day, hour);
-
+       if (!lockdown) {
+           moveRestaurant(day, hour);
+       }
+       
        sendNeighboursHome(day, hour);
     }
 
@@ -219,11 +221,13 @@ public class Household extends Place {
         people.removeAll(left);
     }
 
-    private void moveShop(int day, int hour) {
+    private void moveShop(int day, int hour, boolean lockdown) {
         List<Person> left = new ArrayList();
 
         double visitProb = PopulationParameters.get().getpGoShopping();
-        //TODO: Handle lockdown probabilities
+        if (lockdown) {
+            visitProb = visitProb * 0.5;
+        }
 
         if (RNG.get().nextUniform(0, 1) < visitProb) {
             Shop s = places.getRandomShop();
@@ -272,10 +276,10 @@ public class Household extends Place {
         people.removeAll(left);
     }
 
-    private void moveShift(int day, int hour) {
+    private void moveShift(int day, int hour, boolean lockdown) {
         List<Person> left = new ArrayList();
         for (Person p : getInhabitants()) {
-            if (p.worksNextHour(p.getPrimaryCommunalPlace(), day, hour)) {
+            if (p.worksNextHour(p.getPrimaryCommunalPlace(), day, hour, lockdown)) {
                 if (!p.getQuarantine()) {
                     p.visitPrimaryPlace();
                     left.add(p);

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -90,11 +90,11 @@ public class Household extends Place {
             if (p.mustGoHome(day, hour)) {
                 left.add(p);
                 p.returnHome();
-                left.addAll(sendFamilyHome(p));
+                left.addAll(sendFamilyHome(p, null, day, hour));
             }
             else if (RNG.get().nextUniform(0, 1) < PopulationParameters.get().getHouseholdVisitorLeaveRate()) {
                 left.add(p);
-                left.addAll(sendFamilyHome(p));
+                left.addAll(sendFamilyHome(p, null, day, hour));
                 if (p.cStatus() != CStatus.DEAD) {
                    p.returnHome();
                 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
@@ -18,4 +18,9 @@ public class Nursery extends CommunalPlace {
     public void reportInfection(DailyStats s) {
         s.incInfectionsNursery();
     }
+
+    @Override
+    public void doMovement(int day, int hour) {
+        moveShifts(day, hour);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
@@ -18,9 +18,4 @@ public class Nursery extends CommunalPlace {
     public void reportInfection(DailyStats s) {
         s.incInfectionsNursery();
     }
-
-    @Override
-    public void doMovement(int day, int hour) {
-        moveShifts(day, hour);
-    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
@@ -2,6 +2,7 @@ package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
+import uk.co.ramp.covid.simulation.population.Shifts;
 
 public class Nursery extends CommunalPlace {
 
@@ -12,10 +13,16 @@ public class Nursery extends CommunalPlace {
     public Nursery(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpNurseryTrans();
+        times = OpeningTimes.nineFiveWeekdays();
     }
 
     @Override
     public void reportInfection(DailyStats s) {
         s.incInfectionsNursery();
+    }
+
+    @Override
+    public Shifts getShifts() {
+        return Shifts.schoolTimes();
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
@@ -22,7 +22,13 @@ public class Nursery extends CommunalPlace {
     }
 
     @Override
+    public boolean isFullyStaffed() {
+        return nStaff > 0;
+    }
+
+    @Override
     public Shifts getShifts() {
+        nStaff++;
         return Shifts.schoolTimes();
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -2,6 +2,7 @@ package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
+import uk.co.ramp.covid.simulation.population.Shifts;
 
 public class Office extends CommunalPlace {
 
@@ -9,11 +10,13 @@ public class Office extends CommunalPlace {
         this(Size.UNKNOWN);
     }
 
+
     public Office(Size s)  {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpOfficeTrans();
         keyProb = PopulationParameters.get().getpOfficeKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;
+        times = OpeningTimes.nineFiveWeekdays();
     }
 
     @Override
@@ -21,4 +24,8 @@ public class Office extends CommunalPlace {
         s.incInfectionOffice();
     }
 
+    @Override
+    public Shifts getShifts() {
+        return Shifts.nineFiveFiveDays();
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -26,6 +26,12 @@ public class Office extends CommunalPlace {
 
     @Override
     public Shifts getShifts() {
+        nStaff++;
         return Shifts.nineFiveFiveDays();
+    }
+
+    @Override
+    public boolean isFullyStaffed() {
+        return nStaff > 0;
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -21,9 +21,4 @@ public class Office extends CommunalPlace {
         s.incInfectionOffice();
     }
 
-    @Override
-    public void doMovement(int day, int hour) {
-        moveShifts(day, hour);
-    }
-
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -21,4 +21,9 @@ public class Office extends CommunalPlace {
         s.incInfectionOffice();
     }
 
+    @Override
+    public void doMovement(int day, int hour) {
+        moveShifts(day, hour);
+    }
+
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/OpeningTimes.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/OpeningTimes.java
@@ -101,4 +101,24 @@ public class OpeningTimes {
         }
         return allDays;
     }
+    
+    public static OpeningTimes nineFiveWeekdays() {
+      return new OpeningTimes(9,17, OpeningTimes.getWeekdays());
+    }
+
+    public static OpeningTimes nineFiveAllWeek() {
+        return new OpeningTimes(9,17, OpeningTimes.getAllDays());
+    }
+
+    public static OpeningTimes eightTenAllWeek() {
+        return new OpeningTimes(8,22, OpeningTimes.getAllDays());
+    }
+
+    public static OpeningTimes tenTenAllWeek() {
+        return new OpeningTimes(10,22, OpeningTimes.getAllDays());
+    }
+
+    public static OpeningTimes twentyfourSeven() {
+        return new OpeningTimes(0,24, OpeningTimes.getAllDays());
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/OpeningTimes.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/OpeningTimes.java
@@ -1,0 +1,104 @@
+package uk.co.ramp.covid.simulation.place;
+
+import java.util.BitSet;
+
+/** This class tracks the opening/closing times of the various places */
+public class OpeningTimes {
+    private int open;
+    private int close;
+
+    // Some places may only be open to visitors during the day, e.g. re-stocking at night
+    private int visitorOpen;
+    private int visitorClose;
+
+    // 0 index is Monday; 0011111 => weekday only, 1100000 => weekend only etc.
+    private BitSet openDays;
+
+    OpeningTimes(int open, int close, int vopen, int vclose, BitSet days) {
+        this.open = open;
+        this.close = close;
+        this.visitorOpen = vopen;
+        this.visitorClose = vclose;
+        this.openDays = days;
+    }
+
+    OpeningTimes(int open, int close, BitSet days) {
+        this(open, close, open, close, days);
+    }
+    
+    public boolean isOpen(int time, int day) {
+        return time >= open && time < close && openDays.get(day);
+    }
+
+    public boolean isOpenToVisitors(int time, int day) {
+        return time >= visitorOpen && time < visitorClose && openDays.get(day);
+    }
+
+    public int getOpen() {
+        return open;
+    }
+
+    public void setOpen(int open) {
+        this.open = open;
+    }
+
+    public int getClose() {
+        return close;
+    }
+
+    public void setClose(int close) {
+        this.close = close;
+    }
+
+    public int getVisitorOpen() {
+        return visitorOpen;
+    }
+
+    public void setVisitorOpen(int visitorOpen) {
+        this.visitorOpen = visitorOpen;
+    }
+
+    public int getVisitorClose() {
+        return visitorClose;
+    }
+
+    public void setVisitorClose(int visitorClose) {
+        this.visitorClose = visitorClose;
+    }
+
+    public BitSet getOpenDays() {
+        return openDays;
+    }
+
+    public void setOpenDays(BitSet openDays) {
+        this.openDays = openDays;
+    }
+
+    private static BitSet weekdays;
+    private static BitSet weekend;
+    private static BitSet allDays;
+    
+    public static BitSet getWeekdays() {
+        if (weekdays == null) {
+            weekdays = new BitSet();
+            weekdays.set(0, 4);
+        }
+        return weekdays;
+    }
+    
+    public static BitSet getWeekend() {
+        if (weekend == null) {
+            weekend = new BitSet();
+            weekend.set(5, 6);
+        }
+        return weekend;
+    }
+
+    public static BitSet getAllDays() {
+        if (allDays == null) {
+            allDays = new BitSet();
+            allDays.set(0, 6);
+        }
+        return allDays;
+    }
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/place/OpeningTimes.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/OpeningTimes.java
@@ -81,7 +81,7 @@ public class OpeningTimes {
     public static BitSet getWeekdays() {
         if (weekdays == null) {
             weekdays = new BitSet();
-            weekdays.set(0, 4);
+            weekdays.set(0, 5);
         }
         return weekdays;
     }
@@ -89,7 +89,7 @@ public class OpeningTimes {
     public static BitSet getWeekend() {
         if (weekend == null) {
             weekend = new BitSet();
-            weekend.set(5, 6);
+            weekend.set(5, 7);
         }
         return weekend;
     }
@@ -97,7 +97,7 @@ public class OpeningTimes {
     public static BitSet getAllDays() {
         if (allDays == null) {
             allDays = new BitSet();
-            allDays.set(0, 6);
+            allDays.set(0, 7);
         }
         return allDays;
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -27,13 +27,18 @@ public abstract class Place {
     public List<Person> getPeople() {
         return people;
     }
+    
+    public void addPerson(Person p) {
+        people.add(p);
+    }
 
     private void registerInfection(DailyStats s, Person p) {
         reportInfection(s);
         p.reportInfection(s);
     }
 
-    protected void doInfect(DailyStats stats) {
+    /** Handles infections between all people in this place */
+    public void doInfect(DailyStats stats) {
         List<Person> deaths = new ArrayList<>();
         for (Person cPers : people) {
             if (cPers.getInfectionStatus() && !cPers.isRecovered()) {
@@ -61,4 +66,7 @@ public abstract class Place {
         }
         people.removeAll(deaths);
     }
+
+    /** Handles movement between people in this place */
+    public abstract void doMovement(int day, int hour);
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -85,5 +85,5 @@ public abstract class Place {
     }
 
     /** Handles movement between people in this place */
-    public abstract void doMovement(int day, int hour);
+    public abstract void doMovement(int day, int hour, boolean lockdown);
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -80,10 +80,10 @@ public abstract class Place {
         nextPeople = new ArrayList();
     }
 
-    public List<Person> sendFamilyHome(Person p) {
+    public List<Person> sendFamilyHome(Person p, CommunalPlace place, int day, int hour) {
         List<Person> left = new ArrayList<>();
         for (Person q : people) {
-            if (p != q && q.getHome() == p.getHome()) {
+            if (p != q && !q.worksNextHour(place, day, hour, false) && q.getHome() == p.getHome()) {
                 q.returnHome();
                 left.add(q);
             }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -32,10 +32,7 @@ public abstract class Place {
     public List<Person> getPeople() {
         return people;
     }
-    
-    public void addPerson(Person p) {
-        people.add(p);
-    }
+
     public void addPersonNext(Person p) {
         nextPeople.add(p);
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -12,7 +12,11 @@ import java.util.Set;
 
 public abstract class Place {
 
+    // People are managed in 2 lists, those currently in the place "people" and
+    // those who will be in the place in the next hour "nextPeople"
     protected List<Person> people;
+    protected List<Person> nextPeople;
+    
     protected double sDistance;
     protected double transProb;
 
@@ -20,6 +24,7 @@ public abstract class Place {
 
     public Place() {
         this.people = new ArrayList<>();
+        this.nextPeople = new ArrayList<>();
         this.transProb = PopulationParameters.get().getpBaseTrans();
         this.sDistance = 1.0;
     }
@@ -30,6 +35,9 @@ public abstract class Place {
     
     public void addPerson(Person p) {
         people.add(p);
+    }
+    public void addPersonNext(Person p) {
+        nextPeople.add(p);
     }
 
     private void registerInfection(DailyStats s, Person p) {
@@ -65,6 +73,15 @@ public abstract class Place {
             }
         }
         people.removeAll(deaths);
+    }
+    
+    /** Do a timestep by switching to the new set of people */
+    public void stepPeople() {
+        // Anyone who didn't move should remain.
+        // TODO: might be better to force that they do move even back to the same place.
+        nextPeople.addAll(people);
+        people = nextPeople;
+        nextPeople = new ArrayList();
     }
 
     /** Handles movement between people in this place */

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -78,10 +78,20 @@ public abstract class Place {
     /** Do a timestep by switching to the new set of people */
     public void stepPeople() {
         // Anyone who didn't move should remain.
-        // TODO: might be better to force that they do move even back to the same place.
         nextPeople.addAll(people);
         people = nextPeople;
         nextPeople = new ArrayList();
+    }
+
+    public List<Person> sendFamilyHome(Person p) {
+        List<Person> left = new ArrayList<>();
+        for (Person q : people) {
+            if (p != q && q.getHome() == p.getHome()) {
+                q.returnHome();
+                left.add(q);
+            }
+        }
+        return left;
     }
 
     /** Handles movement between people in this place */

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -32,7 +32,6 @@ public class Restaurant extends CommunalPlace {
                 left.add(nPers);
                 nPers.returnHome();
             }
-            // TODO: average dining time should be a parameter
             else if (rng.nextUniform(0, 1) < PopulationParameters.get().getpLeaveRestaurant()
                     || !times.isOpen(hour + 1, day)) {
                 left.add(nPers);
@@ -49,8 +48,8 @@ public class Restaurant extends CommunalPlace {
     }
 
     @Override
-    public void doMovement(int day, int hour) {
-        moveShifts(day, hour);
+    public void doMovement(int day, int hour, boolean lockdown) {
+        moveShifts(day, hour, lockdown);
         sendHome(day, hour);
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -64,17 +64,21 @@ public class Restaurant extends CommunalPlace {
                 continue;
             }
 
+            if (nPers.worksNextHour(this, day, hour, false)) {
+                continue;
+            }
+
             // Under certain conditions we must go home, e.g. if there is a shift starting soon
             if (nPers.mustGoHome(day, hour)) {
                 left.add(nPers);
                 nPers.returnHome();
-                left.addAll(sendFamilyHome(nPers));
+                left.addAll(sendFamilyHome(nPers, this, day, hour));
             }
             else if (rng.nextUniform(0, 1) < PopulationParameters.get().getpLeaveRestaurant()
                     || !times.isOpen(hour + 1, day)) {
                 left.add(nPers);
                 nPers.returnHome();
-                left.addAll(sendFamilyHome(nPers));
+                left.addAll(sendFamilyHome(nPers, this, day, hour));
             }
         }
         people.removeAll(left);

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -43,7 +43,13 @@ public class Restaurant extends CommunalPlace {
 
     @Override
     public Shifts getShifts() {
+        nStaff++;
         return shifts.getNext();
+    }
+
+    @Override
+    public boolean isFullyStaffed() {
+        return nStaff >= 4;
     }
 
     public void shoppingTrip(ArrayList<Person> vHouse) {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -3,10 +3,15 @@ package uk.co.ramp.covid.simulation.place;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
+import uk.co.ramp.covid.simulation.population.Shifts;
+import uk.co.ramp.covid.simulation.util.RNG;
+import uk.co.ramp.covid.simulation.util.RoundRobinAllocator;
 
 import java.util.ArrayList;
 
 public class Restaurant extends CommunalPlace {
+
+    private RoundRobinAllocator<Shifts> shifts;
 
     public Restaurant() {
         this(Size.UNKNOWN);
@@ -15,9 +20,30 @@ public class Restaurant extends CommunalPlace {
     public Restaurant(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpRestaurantTrans();
-        times.setOpen(10);
-        times.setClose(22);
         keyPremises = false;
+        setOpeningHours();
+    }
+
+    private void setOpeningHours() {
+        shifts = new RoundRobinAllocator<>();
+        if (RNG.get().nextUniform(0, 1) < 0.5) {
+            times = OpeningTimes.eightTenAllWeek();
+            shifts.put(new Shifts(8, 15, 0, 1, 2));
+            shifts.put(new Shifts(15, 22, 0, 1, 2));
+            shifts.put(new Shifts(8, 15, 3, 4, 5, 6));
+            shifts.put(new Shifts(15, 22, 3, 4, 5, 6));
+        } else {
+            times = OpeningTimes.tenTenAllWeek();
+            shifts.put(new Shifts(10, 16, 0, 1, 2));
+            shifts.put(new Shifts(16, 22, 0, 1, 2));
+            shifts.put(new Shifts(10, 16, 3, 4, 5, 6));
+            shifts.put(new Shifts(16, 22, 3, 4, 5, 6));
+        }
+    }
+
+    @Override
+    public Shifts getShifts() {
+        return shifts.getNext();
     }
 
     public void shoppingTrip(ArrayList<Person> vHouse) {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -15,10 +15,8 @@ public class Restaurant extends CommunalPlace {
     public Restaurant(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpRestaurantTrans();
-        startDay = 1;
-        endDay = 7;
-        startTime = 10;
-        endTime = 22;
+        times.setOpen(10);
+        times.setClose(22);
         keyPremises = false;
     }
 
@@ -26,11 +24,12 @@ public class Restaurant extends CommunalPlace {
         people.addAll(vHouse);
     }
 
-    public int sendHome(int hour) {
+    public int sendHome(int hour, int day) {
         ArrayList<Person> left = new ArrayList<>();
         for (Person nPers : people) {
+            // TODO: average dining time should be a parameter
             if (!nPers.isShopWorker() && rng.nextUniform(0, 1) < 0.4
-                    || hour < super.endTime) { // Assumes a median lenght of shopping trip of 2 hours
+                    || !times.isOpen(hour + 1,day)) {
                 left.add(nPers);
                 nPers.returnHome();
             }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -27,9 +27,13 @@ public class Restaurant extends CommunalPlace {
     public int sendHome(int day, int hour) {
         ArrayList<Person> left = new ArrayList<>();
         for (Person nPers : people) {
+            // Under certain conditions we must go home, e.g. if there is a shift starting soon
+            if (nPers.mustGoHome(day, hour)) {
+                left.add(nPers);
+                nPers.returnHome();
+            }
             // TODO: average dining time should be a parameter
-            if (!nPers.isShopWorker() && rng.nextUniform(0, 1) < 0.4
-                    || !times.isOpen(hour + 1, day)) {
+            else if (rng.nextUniform(0, 1) < 0.4 || !times.isOpen(hour + 1, day)) {
                 left.add(nPers);
                 nPers.returnHome();
             }
@@ -43,11 +47,10 @@ public class Restaurant extends CommunalPlace {
         s.incInfectionsRestaurant();
     }
 
-    // TODO: Specialised handling for restaurants
     @Override
     public void doMovement(int day, int hour) {
         moveShifts(day, hour);
-        //sendHome(day, hour);
+        sendHome(day, hour);
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -33,7 +33,8 @@ public class Restaurant extends CommunalPlace {
                 nPers.returnHome();
             }
             // TODO: average dining time should be a parameter
-            else if (rng.nextUniform(0, 1) < 0.4 || !times.isOpen(hour + 1, day)) {
+            else if (rng.nextUniform(0, 1) < PopulationParameters.get().getpLeaveRestaurant()
+                    || !times.isOpen(hour + 1, day)) {
                 left.add(nPers);
                 nPers.returnHome();
             }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -24,12 +24,12 @@ public class Restaurant extends CommunalPlace {
         people.addAll(vHouse);
     }
 
-    public int sendHome(int hour, int day) {
+    public int sendHome(int day, int hour) {
         ArrayList<Person> left = new ArrayList<>();
         for (Person nPers : people) {
             // TODO: average dining time should be a parameter
             if (!nPers.isShopWorker() && rng.nextUniform(0, 1) < 0.4
-                    || !times.isOpen(hour + 1,day)) {
+                    || !times.isOpen(hour + 1, day)) {
                 left.add(nPers);
                 nPers.returnHome();
             }
@@ -41,6 +41,13 @@ public class Restaurant extends CommunalPlace {
     @Override
     public void reportInfection(DailyStats s) {
         s.incInfectionsRestaurant();
+    }
+
+    // TODO: Specialised handling for restaurants
+    @Override
+    public void doMovement(int day, int hour) {
+        moveShifts(day, hour);
+        //sendHome(day, hour);
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -53,15 +53,22 @@ public class Restaurant extends CommunalPlace {
     public int sendHome(int day, int hour) {
         ArrayList<Person> left = new ArrayList<>();
         for (Person nPers : people) {
+            // People may have already left if their family has
+            if (left.contains(nPers)) {
+                continue;
+            }
+
             // Under certain conditions we must go home, e.g. if there is a shift starting soon
             if (nPers.mustGoHome(day, hour)) {
                 left.add(nPers);
                 nPers.returnHome();
+                left.addAll(sendFamilyHome(nPers));
             }
             else if (rng.nextUniform(0, 1) < PopulationParameters.get().getpLeaveRestaurant()
                     || !times.isOpen(hour + 1, day)) {
                 left.add(nPers);
                 nPers.returnHome();
+                left.addAll(sendFamilyHome(nPers));
             }
         }
         people.removeAll(left);

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -21,8 +21,4 @@ public class School extends CommunalPlace {
         s.incInfectionsSchool();
     }
 
-    @Override
-    public void doMovement(int day, int hour) {
-        moveShifts(day, hour);
-    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -10,8 +10,9 @@ public class School extends CommunalPlace {
 
     public School(Size s) {
         super(s);
-        int startTime = 9; // TODO. Not used at the moment, but may be used in the future. LEave them in for completeness
-        int endTime = 15;
+        times.setOpen(9);
+        times.setClose(15);
+        times.setOpenDays(OpeningTimes.getWeekdays());
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpSchoolTrans();
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -20,4 +20,9 @@ public class School extends CommunalPlace {
     public void reportInfection(DailyStats s) {
         s.incInfectionsSchool();
     }
+
+    @Override
+    public void doMovement(int day, int hour) {
+        moveShifts(day, hour);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -2,23 +2,29 @@ package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
+import uk.co.ramp.covid.simulation.population.Shifts;
 
 public class School extends CommunalPlace {
     public School() {
         this(Size.UNKNOWN);
     }
 
+
     public School(Size s) {
         super(s);
-        times.setOpen(9);
-        times.setClose(15);
-        times.setOpenDays(OpeningTimes.getWeekdays());
+        times = OpeningTimes.nineFiveWeekdays();
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpSchoolTrans();
     }
 
     @Override
     public void reportInfection(DailyStats s) {
         s.incInfectionsSchool();
+    }
+
+
+    @Override
+    public Shifts getShifts() {
+        return Shifts.schoolTimes();
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -24,7 +24,13 @@ public class School extends CommunalPlace {
 
     @Override
     public Shifts getShifts() {
+        nStaff++;
         return Shifts.schoolTimes();
+    }
+
+    @Override
+    public boolean isFullyStaffed() {
+        return nStaff > 0;
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -51,15 +51,22 @@ public class Shop extends CommunalPlace {
     public int sendHome(int day, int hour) {
         ArrayList<Person> left = new ArrayList<>();
         for (Person nPers : people) {
+            // People may have already left if their family has
+            if (left.contains(nPers)) {
+                continue;
+            }
+
             // Under certain conditions we must go home, e.g. if there is a shift starting soon
             if (nPers.mustGoHome(day, hour)) {
                 left.add(nPers);
                 nPers.returnHome();
+                left.addAll(sendFamilyHome(nPers));
             }
             else if (rng.nextUniform(0, 1) < PopulationParameters.get().getpLeaveShop()
                     || !times.isOpen(hour + 1, day)) {
                 nPers.returnHome();
                 left.add(nPers);
+                left.addAll(sendFamilyHome(nPers));
             }
         }
         people.removeAll(left);

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -32,7 +32,6 @@ public class Shop extends CommunalPlace {
                 left.add(nPers);
                 nPers.returnHome();
             }
-            // TODO: Average shopping time should be a parameter
             else if (rng.nextUniform(0, 1) < PopulationParameters.get().getpLeaveShop()
                     || !times.isOpen(hour + 1, day)) {
                 nPers.returnHome();
@@ -49,8 +48,8 @@ public class Shop extends CommunalPlace {
     }
 
     @Override
-    public void doMovement(int day, int hour) {
-        moveShifts(day, hour);
+    public void doMovement(int day, int hour, boolean lockdown) {
+        moveShifts(day, hour, lockdown);
         sendHome(day, hour);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -15,8 +15,6 @@ public class Shop extends CommunalPlace {
     public Shop(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() *  PopulationParameters.get().getpShopTrans();
-        //startDay = 1;
-        //endDay = 7;
         keyProb = PopulationParameters.get().getpShopKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;
 
@@ -35,7 +33,8 @@ public class Shop extends CommunalPlace {
                 nPers.returnHome();
             }
             // TODO: Average shopping time should be a parameter
-            else if (rng.nextUniform(0, 1) < 0.5 || !times.isOpen(hour + 1, day)) {
+            else if (rng.nextUniform(0, 1) < PopulationParameters.get().getpLeaveShop()
+                    || !times.isOpen(hour + 1, day)) {
                 nPers.returnHome();
                 left.add(nPers);
             }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -15,8 +15,8 @@ public class Shop extends CommunalPlace {
     public Shop(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() *  PopulationParameters.get().getpShopTrans();
-        startDay = 1;
-        endDay = 7;
+        //startDay = 1;
+        //endDay = 7;
         keyProb = PopulationParameters.get().getpShopKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;
 
@@ -26,11 +26,12 @@ public class Shop extends CommunalPlace {
        people.addAll(vHouse);
     }
 
-    public int sendHome(int hour) {
+    public int sendHome(int hour, int day) {
         ArrayList<Person> left = new ArrayList<>();
         for (Person nPers : people) {
+            // TODO: Average shopping time should be a parameter
             if (!nPers.isShopWorker() && rng.nextUniform(0, 1) < 0.5 
-                    || hour < super.endTime) {// Assumes a median lenght of shopping trip of 2 hours
+                    || !times.isOpen(hour + 1, day)) {
                 left.add(nPers);
                 nPers.returnHome();
             }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -29,11 +29,15 @@ public class Shop extends CommunalPlace {
     public int sendHome(int day, int hour) {
         ArrayList<Person> left = new ArrayList<>();
         for (Person nPers : people) {
-            // TODO: Average shopping time should be a parameter
-            if (!nPers.isShopWorker() && rng.nextUniform(0, 1) < 0.5 
-                    || !times.isOpen(hour + 1, day)) {
+            // Under certain conditions we must go home, e.g. if there is a shift starting soon
+            if (nPers.mustGoHome(day, hour)) {
                 left.add(nPers);
                 nPers.returnHome();
+            }
+            // TODO: Average shopping time should be a parameter
+            else if (rng.nextUniform(0, 1) < 0.5 || !times.isOpen(hour + 1, day)) {
+                nPers.returnHome();
+                left.add(nPers);
             }
         }
         people.removeAll(left);
@@ -48,6 +52,6 @@ public class Shop extends CommunalPlace {
     @Override
     public void doMovement(int day, int hour) {
         moveShifts(day, hour);
-        //sendHome(day, hour);
+        sendHome(day, hour);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -3,10 +3,14 @@ package uk.co.ramp.covid.simulation.place;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
+import uk.co.ramp.covid.simulation.population.Shifts;
+import uk.co.ramp.covid.simulation.util.RoundRobinAllocator;
 
 import java.util.ArrayList;
 
 public class Shop extends CommunalPlace {
+    
+    private RoundRobinAllocator<Shifts> shifts;
 
     public Shop() {
         this(Size.UNKNOWN);
@@ -17,7 +21,27 @@ public class Shop extends CommunalPlace {
         transProb = PopulationParameters.get().getpBaseTrans() *  PopulationParameters.get().getpShopTrans();
         keyProb = PopulationParameters.get().getpShopKey();
         if (rng.nextUniform(0, 1) > keyProb) keyPremises = true;
+        setOpeningHours();
+    }
+    
+    private void setOpeningHours() {
+        shifts = new RoundRobinAllocator();
+        if (size == Size.SMALL) {
+            times = OpeningTimes.nineFiveAllWeek();
+            shifts.put(new Shifts(9,17, 0, 1, 2));
+            shifts.put(new Shifts(9,17, 3, 4, 5, 6));
+        } else {
+            times = OpeningTimes.eightTenAllWeek();
+            shifts.put(new Shifts(8,15, 0, 1, 2));
+            shifts.put(new Shifts(15,22, 0, 1, 2));
+            shifts.put(new Shifts(8,15, 3, 4, 5, 6));
+            shifts.put(new Shifts(15,22, 3, 4, 5, 6));
+        }
+    }
 
+    @Override
+    public Shifts getShifts() {
+        return shifts.getNext();
     }
 
     public void shoppingTrip(ArrayList<Person> vHouse) {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -57,17 +57,21 @@ public class Shop extends CommunalPlace {
                 continue;
             }
 
+            if (nPers.worksNextHour(this, day, hour, false)) {
+                continue;
+            }
+
             // Under certain conditions we must go home, e.g. if there is a shift starting soon
             if (nPers.mustGoHome(day, hour)) {
                 left.add(nPers);
                 nPers.returnHome();
-                left.addAll(sendFamilyHome(nPers));
+                left.addAll(sendFamilyHome(nPers, this, day, hour));
             }
             else if (rng.nextUniform(0, 1) < PopulationParameters.get().getpLeaveShop()
                     || !times.isOpen(hour + 1, day)) {
                 nPers.returnHome();
                 left.add(nPers);
-                left.addAll(sendFamilyHome(nPers));
+                left.addAll(sendFamilyHome(nPers, this, day, hour));
             }
         }
         people.removeAll(left);

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -26,7 +26,7 @@ public class Shop extends CommunalPlace {
        people.addAll(vHouse);
     }
 
-    public int sendHome(int hour, int day) {
+    public int sendHome(int day, int hour) {
         ArrayList<Person> left = new ArrayList<>();
         for (Person nPers : people) {
             // TODO: Average shopping time should be a parameter
@@ -43,5 +43,11 @@ public class Shop extends CommunalPlace {
     @Override
     public void reportInfection(DailyStats s) {
         s.incInfectionsShop();
+    }
+
+    @Override
+    public void doMovement(int day, int hour) {
+        moveShifts(day, hour);
+        //sendHome(day, hour);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -41,6 +41,7 @@ public class Shop extends CommunalPlace {
 
     @Override
     public Shifts getShifts() {
+        nStaff++;
         return shifts.getNext();
     }
 
@@ -82,5 +83,10 @@ public class Shop extends CommunalPlace {
     public void doMovement(int day, int hour, boolean lockdown) {
         moveShifts(day, hour, lockdown);
         sendHome(day, hour);
+    }
+
+    @Override
+    public boolean isFullyStaffed() {
+        return nStaff >= 4;
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
@@ -2,6 +2,9 @@ package uk.co.ramp.covid.simulation.population;
 
 import uk.co.ramp.covid.simulation.CovidParameters;
 import uk.co.ramp.covid.simulation.DailyStats;
+import uk.co.ramp.covid.simulation.place.Hospital;
+import uk.co.ramp.covid.simulation.place.Restaurant;
+import uk.co.ramp.covid.simulation.place.Shop;
 import uk.co.ramp.covid.simulation.util.ProbabilityDistribution;
 
 public class Adult extends Person {
@@ -14,7 +17,6 @@ public class Adult extends Person {
 
     public Adult() {
         setProfession();
-        shifts = Shifts.getAllTimes();
     }
 
     // Allocates adults to different professions
@@ -29,10 +31,6 @@ public class Adult extends Person {
         p.add(PopulationParameters.get().getpUnemployed(), Professions.NONE);
 
         profession = p.sample();
-        // There is special logic for shop workers returning home
-        if (profession == Professions.SHOP) {
-            super.setShopWorker();
-        }
     }
 
     @Override
@@ -50,21 +48,30 @@ public class Adult extends Person {
         switch(profession) {
             case TEACHER: {
                 setPrimaryPlace(p.getRandomSchool());
+                shifts = Shifts.schoolTimes();
             } break;
             case SHOP: {
-                setPrimaryPlace(p.getRandomShop());
+                Shop s = p.getRandomShop();
+                setPrimaryPlace(s);
+                shifts = s.getShifts();
             } break;
             case CONSTRUCTION: {
                 setPrimaryPlace(p.getRandomConstructionSite());
+                shifts = Shifts.nineFiveFiveDays();
             } break;
             case OFFICE: {
                 setPrimaryPlace(p.getRandomOffice());
+                shifts = Shifts.nineFiveFiveDays();
             } break;
             case HOSPITAL: {
-                setPrimaryPlace(p.getRandomHospital());
+                Hospital h = p.getRandomHospital();
+                setPrimaryPlace(h);
+                shifts = h.getShifts();
             } break;
             case RESTAURANT: {
-                setPrimaryPlace(p.getRandomRestaurant());
+                Restaurant r = p.getRandomRestaurant();
+                setPrimaryPlace(r);
+                shifts = r.getShifts();
             } break;
         }
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
@@ -12,9 +12,10 @@ public class Adult extends Person {
 
     Professions profession;
 
-    public Adult() { setProfession(); }
-
-
+    public Adult() {
+        setProfession();
+        shifts = Shifts.getAllTimes();
+    }
 
     // Allocates adults to different professions
     public void setProfession() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
@@ -2,15 +2,13 @@ package uk.co.ramp.covid.simulation.population;
 
 import uk.co.ramp.covid.simulation.CovidParameters;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.place.Hospital;
-import uk.co.ramp.covid.simulation.place.Restaurant;
-import uk.co.ramp.covid.simulation.place.Shop;
+import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.util.ProbabilityDistribution;
 
 public class Adult extends Person {
 
     public enum Professions {
-        OFFICE, SHOP, HOSPITAL, CONSTRUCTION, TEACHER, RESTAURANT, NONE
+        OFFICE, SHOP, HOSPITAL, CONSTRUCTION, TEACHER, RESTAURANT, NURSERY, NONE
     }
 
     Professions profession;
@@ -28,6 +26,7 @@ public class Adult extends Person {
         p.add(PopulationParameters.get().getpConstructionWorker(), Professions.CONSTRUCTION);
         p.add(PopulationParameters.get().getpTeacher(), Professions.TEACHER);
         p.add(PopulationParameters.get().getpRestaurantWorker(), Professions.RESTAURANT);
+        p.add(PopulationParameters.get().getpNurseryWorker(), Professions.NURSERY);
         p.add(PopulationParameters.get().getpUnemployed(), Professions.NONE);
 
         profession = p.sample();
@@ -47,8 +46,14 @@ public class Adult extends Person {
     public void allocateCommunalPlace(Places p) {
         switch(profession) {
             case TEACHER: {
-                setPrimaryPlace(p.getRandomSchool());
-                shifts = Shifts.schoolTimes();
+                School s = p.getRandomSchool();
+                setPrimaryPlace(s);
+                shifts = s.getShifts();
+            } break;
+            case NURSERY: {
+                Nursery s = p.getRandomNursery();
+                setPrimaryPlace(s);
+                shifts = s.getShifts();
             } break;
             case SHOP: {
                 Shop s = p.getRandomShop();
@@ -56,12 +61,14 @@ public class Adult extends Person {
                 shifts = s.getShifts();
             } break;
             case CONSTRUCTION: {
-                setPrimaryPlace(p.getRandomConstructionSite());
-                shifts = Shifts.nineFiveFiveDays();
+                ConstructionSite s = p.getRandomConstructionSite();
+                setPrimaryPlace(s);
+                shifts = s.getShifts();
             } break;
             case OFFICE: {
-                setPrimaryPlace(p.getRandomOffice());
-                shifts = Shifts.nineFiveFiveDays();
+                Office s = p.getRandomOffice();
+                setPrimaryPlace(s);
+                shifts = s.getShifts();
             } break;
             case HOSPITAL: {
                 Hospital h = p.getRandomHospital();

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Child.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Child.java
@@ -5,7 +5,9 @@ import uk.co.ramp.covid.simulation.DailyStats;
 
 public class Child extends Person {
 
-    public Child() { }
+    public Child() {
+        shifts = Shifts.getSchoolTimes();
+    }
 
     @Override
     public void reportInfection(DailyStats s) {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Child.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Child.java
@@ -6,7 +6,7 @@ import uk.co.ramp.covid.simulation.DailyStats;
 public class Child extends Person {
 
     public Child() {
-        shifts = Shifts.getSchoolTimes();
+        shifts = Shifts.schoolTimes();
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Infant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Infant.java
@@ -9,6 +9,7 @@ public class Infant extends Person {
 
     public Infant() {
         setNursery();
+        shifts = Shifts.getSchoolTimes();
     }
 
     private void setNursery() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Infant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Infant.java
@@ -9,7 +9,7 @@ public class Infant extends Person {
 
     public Infant() {
         setNursery();
-        shifts = Shifts.getSchoolTimes();
+        shifts = Shifts.schoolTimes();
     }
 
     private void setNursery() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -12,8 +12,6 @@ import uk.co.ramp.covid.simulation.place.Household;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 public abstract class Person {
-    private boolean shopWorker = false;
-
     private CommunalPlace primaryPlace = null;
     protected Shifts shifts = null;
 
@@ -36,16 +34,7 @@ public abstract class Person {
         this.quarantineProb = PopulationParameters.get().getpQuarantine();
         this.quarantineVal = rng.nextUniform(0, 1);
     }
-    
-    public void setShopWorker() {
-        shopWorker = true;
-    }
 
-    public boolean isShopWorker() {
-        return shopWorker;
-    }
-
-   
     public boolean isRecovered() {
         return recovered;
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -11,6 +11,8 @@ import uk.co.ramp.covid.simulation.place.CommunalPlace;
 import uk.co.ramp.covid.simulation.place.Household;
 import uk.co.ramp.covid.simulation.util.RNG;
 
+import java.util.ArrayList;
+
 public abstract class Person {
     private boolean shopWorker = false;
 
@@ -139,4 +141,20 @@ public abstract class Person {
     }
 
     public abstract boolean avoidsPhase2(double testP);
+
+    public boolean worksNextHour(CommunalPlace communalPlace, int day, int hour) {
+        if (shifts == null) {
+            return false;
+        }
+
+        return primaryPlace == communalPlace
+                && hour + 1 >= shifts.getShift(day).getStart()
+                || hour + 1 < shifts.getShift(day).getEnd();
+    }
+
+    public void visitPrimaryPlace() {
+        if (primaryPlace != null) {
+            primaryPlace.addPerson(this);
+        }
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -13,7 +13,10 @@ import uk.co.ramp.covid.simulation.util.RNG;
 
 public abstract class Person {
     private boolean shopWorker = false;
+
     private CommunalPlace primaryPlace = null;
+    protected Shifts shifts = null;
+
     private Household home;
     private boolean recovered;
     private Covid cVirus;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -139,10 +139,17 @@ public abstract class Person {
             return false;
         }
 
+        // Handle day crossovers
+        int start = shifts.getShift(day).getStart();
+        int end = shifts.getShift(day).getEnd();
+        if (end < start) {
+            end += 24;
+        }
+
         boolean shouldWork =
                 primaryPlace == communalPlace
-                && hour + 1 >= shifts.getShift(day).getStart()
-                && hour + 1 < shifts.getShift(day).getEnd();
+                && hour + 1 >= start
+                && hour + 1 < end;
         
         if (lockdown) {
             if (communalPlace.isKeyPremises()) {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -11,8 +11,6 @@ import uk.co.ramp.covid.simulation.place.CommunalPlace;
 import uk.co.ramp.covid.simulation.place.Household;
 import uk.co.ramp.covid.simulation.util.RNG;
 
-import java.util.ArrayList;
-
 public abstract class Person {
     private boolean shopWorker = false;
 
@@ -73,7 +71,7 @@ public abstract class Person {
     }
     
     public void returnHome() {
-        home.addInhabitant(this);
+        home.addPersonNext(this);
     }
 
     public boolean getQuarantine() {
@@ -142,19 +140,29 @@ public abstract class Person {
 
     public abstract boolean avoidsPhase2(double testP);
 
+    // TODO: Don't think this works for non-workers etc
     public boolean worksNextHour(CommunalPlace communalPlace, int day, int hour) {
-        if (shifts == null) {
+        if (primaryPlace == null || shifts == null) {
             return false;
         }
 
         return primaryPlace == communalPlace
                 && hour + 1 >= shifts.getShift(day).getStart()
-                || hour + 1 < shifts.getShift(day).getEnd();
+                && hour + 1 < shifts.getShift(day).getEnd();
     }
 
     public void visitPrimaryPlace() {
         if (primaryPlace != null) {
-            primaryPlace.addPerson(this);
+            primaryPlace.addPersonNext(this);
         }
+    }
+
+    // People need to leave early if they have a shift starting in 2 hours time
+    // 1 hour travels home, 1 travels to work; There is currently no direct travel to work.
+    public boolean mustGoHome(int day, int hour) {
+        if (primaryPlace != null && shifts != null) {
+            return hour + 2 >= shifts.getShift(day).getStart();
+        }
+        return false;
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -139,16 +139,26 @@ public abstract class Person {
     }
 
     public abstract boolean avoidsPhase2(double testP);
-
-    // TODO: Don't think this works for non-workers etc
-    public boolean worksNextHour(CommunalPlace communalPlace, int day, int hour) {
+    
+    public boolean worksNextHour(CommunalPlace communalPlace, int day, int hour, boolean lockdown) {
         if (primaryPlace == null || shifts == null) {
             return false;
         }
 
-        return primaryPlace == communalPlace
+        boolean shouldWork =
+                primaryPlace == communalPlace
                 && hour + 1 >= shifts.getShift(day).getStart()
                 && hour + 1 < shifts.getShift(day).getEnd();
+        
+        if (lockdown) {
+            if (communalPlace.isKeyPremises()) {
+                return shouldWork;
+            } else {
+                return false;
+            }
+        }
+        
+        return shouldWork;
     }
 
     public void visitPrimaryPlace() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
@@ -32,7 +32,6 @@ public class Places {
         shops = new ProbabilityDistribution<>();
         all = new ArrayList<>();
     }
-    
 
     public Office getRandomOffice() {
         return offices.sample();

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -291,12 +291,22 @@ public class Population {
             p.doInfect(dStats);
         }
 
+        // Movement places people in "next" buffers (to avoid people moving twice)
         for (Place p : population) {
             p.doMovement(day, hour);
         }
 
         for (Place p : places.getAllPlaces()) {
             p.doMovement(day, hour);
+        }
+
+        // Step flips the buffers, completing the movement
+        for (Place p : population) {
+            p.stepPeople();
+        }
+
+        for (Place p : places.getAllPlaces()) {
+            p.stepPeople();
         }
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -279,13 +279,13 @@ public class Population {
         places.getAllPlaces().forEach(p -> p.doInfect(dStats));
 
         // There is a potential to introduce parallelism here if required by using parallelStream (see below).
-        // Note we currently cannot parallelise movement as the ArrayLists for caoturing moves are not thread safe
+        // Note we currently cannot parallelise movement as the ArrayLists for capturing moves are not thread safe
         // households.parallelStream().forEach(h -> h.doInfect(dStats));
         // places.getAllPlaces().parallelStream().forEach(p -> p.doInfect(dStats));
 
         // Movement places people in "next" buffers (to avoid people moving twice in an hour)
-        households.forEach(h -> h.doMovement(day, hour));
-        places.getAllPlaces().forEach(p -> p.doMovement(day, hour));
+        households.forEach(h -> h.doMovement(day, hour, lockdown));
+        places.getAllPlaces().forEach(p -> p.doMovement(day, hour, lockdown));
 
         households.forEach(h -> h.stepPeople());
         places.getAllPlaces().forEach(p -> p.stepPeople());

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -281,14 +281,14 @@ public class Population {
         List<DailyStats> stats = new ArrayList<>(nDays);
         for (int i = 0; i < nDays; i++) {
             DailyStats dStats = new DailyStats(i);
-            int dWeek = (i + 1) % 7;
+            int dWeek = i % 7;
             this.implementLockdown(i);
             LOGGER.info("Lockdown = {}", this.lockdown);
             for (int k = 0; k < 24; k++) {
                 this.cycleHouseholds(dWeek, k, dStats);
-                this.cyclePlaces(k, dStats);
-                this.returnShoppers(k);
-                this.returnRestaurant(k);
+                this.cyclePlaces(k, dWeek, dStats);
+                this.returnShoppers(k, dWeek);
+                this.returnRestaurant(k, dWeek);
                 this.shoppingTrip(dWeek, k);
                 if (!this.rLockdown) this.restaurantTrip(dWeek, k);
             }
@@ -369,8 +369,8 @@ public class Population {
     }
 
     // People returning ome at the end of the day
-    private void cyclePlaces(int hour, DailyStats stats) {
-        places.getAllPlaces().forEach(p -> p.cyclePlace(hour,stats));
+    private void cyclePlaces(int hour, int day, DailyStats stats) {
+        places.getAllPlaces().forEach(p -> p.cyclePlace(hour, day, stats));
     }
 
     // Go through neighbours and see if they visit anybody
@@ -410,8 +410,8 @@ public class Population {
     }
 
     // People return from shopping
-    private void returnShoppers(int hour) {
-        places.getShops().forEach(s -> s.sendHome(hour));
+    private void returnShoppers(int hour, int day) {
+        places.getShops().forEach(s -> s.sendHome(hour, day));
     }
 
     // People go out for dinner
@@ -438,8 +438,8 @@ public class Population {
     }
 
     // People return from dinner
-    private void returnRestaurant(int hour) {
-        places.getRestaurants().forEach(r -> r.sendHome(hour));
+    private void returnRestaurant(int hour, int day) {
+        places.getRestaurants().forEach(r -> r.sendHome(hour, day));
     }
 
     public Household[] getPopulation() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
@@ -18,6 +18,7 @@ public class PopulationParameters {
     private static PopulationParameters pp = null;
     private static final double EPSILON = 0.001;
 
+
     // Proportions of each type of person in the population
     private static class Population {
         public Double pInfants = null;
@@ -186,6 +187,7 @@ public class PopulationParameters {
         public Double pTeacher = null;
         public Double pRestaurant = null;
         public Double pUnemployed = null;
+        public Double pNursery = null;
 
         public Size sizeAllocation = null;
 
@@ -199,6 +201,8 @@ public class PopulationParameters {
                     ", pTeacher=" + pTeacher +
                     ", pRestaurant=" + pRestaurant +
                     ", pUnemployed=" + pUnemployed +
+                    ", pNursery=" + pNursery +
+                    ", sizeAllocation=" + sizeAllocation +
                     '}';
         }
 
@@ -209,9 +213,10 @@ public class PopulationParameters {
                     && isValidProbability(pConstruction, "pConstruction")
                     && isValidProbability(pTeacher, "pTeacher")
                     && isValidProbability(pRestaurant, "pRestaurant")
+                    && isValidProbability(pNursery, "pNursery")
                     && isValidProbability(pUnemployed, "pUnemployed");
 
-            double totalP = pOffice + pShop + pHospital + pConstruction + pTeacher + pRestaurant + pUnemployed;
+            double totalP = pOffice + pShop + pHospital + pConstruction + pTeacher + pRestaurant + pNursery + pUnemployed;
             if(!(totalP <= 1 + EPSILON && totalP >= 1 - EPSILON)) {
                 LOGGER.error("Worker allocation parameter probabilities do not total one");
                 return false;
@@ -595,6 +600,8 @@ public class PopulationParameters {
     public double getpRestaurantWorker() {
         return workerAllocation.pRestaurant;
     }
+
+    public double getpNurseryWorker() { return workerAllocation.pNursery; }
 
     public double getpUnemployed() {
         return workerAllocation.pUnemployed;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
@@ -235,6 +235,9 @@ public class PopulationParameters {
         public Double pConstructionSiteKey = null;
         public Double pOfficeKey = null;
         public Double pShopKey = null;
+        
+        public Double pLeaveShop = null;
+        public Double pLeaveRestaurant = null;
 
         @Override
         public String toString() {
@@ -251,6 +254,8 @@ public class PopulationParameters {
                     ", pConstructionSiteKey=" + pConstructionSiteKey +
                     ", pOfficeKey=" + pOfficeKey +
                     ", pShopKey=" + pShopKey +
+                    ", pLeaveShop =" + pLeaveShop +
+                    ", pLeaveRestaurant =" + pLeaveRestaurant +
                     '}';
         }
 
@@ -266,7 +271,9 @@ public class PopulationParameters {
                     && isValidProbability(pHospitalKey, "pHospitalKey")
                     && isValidProbability(pConstructionSiteKey, "pConstructionSiteKey")
                     && isValidProbability(pOfficeKey, "pOfficeKey")
-                    && isValidProbability(pShopKey, "pShopKey");
+                    && isValidProbability(pShopKey, "pShopKey")
+                    && isValidProbability(pLeaveShop, "pLeaveShop")
+                    && isValidProbability(pLeaveRestaurant, "pLeaveRestaurant");
         }
     }
 
@@ -310,13 +317,23 @@ public class PopulationParameters {
         public Double neighbourVisitFreq = null;
         public Integer expectedNeighbours = null;
 
+        public Double pGoShopping = null;
+        public Double pGoRestaurant = null;
+
         @Override
         public String toString() {
             return "HouseholdProperties{" +
                     "visitorLeaveRate=" + visitorLeaveRate +
                     ", neighbourVisitFreq=" + neighbourVisitFreq +
                     ", expectedNeighbours=" + expectedNeighbours +
+                    ", pGoShopping=" + pGoShopping +
+                    ", pGoRestaurant=" + pGoRestaurant +
                     '}';
+        }
+
+        public boolean isValid() {
+            return isValidProbability(pGoShopping, "pGoShopping")
+                    && isValidProbability(pGoRestaurant, "pGoRestaurant");
         }
     }
 
@@ -632,6 +649,22 @@ public class PopulationParameters {
         return buildingProperties.pShopKey;
     }
 
+    public double getpLeaveShop () {
+        return buildingProperties.pLeaveShop;
+    }
+
+    public void setpLeaveShop (double p) {
+        buildingProperties.pLeaveShop = p;
+    }
+
+    public double getpLeaveRestaurant () {
+        return buildingProperties.pLeaveRestaurant;
+    }
+
+    public void setpLeaveRestaurant (double p) {
+        buildingProperties.pLeaveRestaurant = p;
+    }
+
     // Infant allocation
     public double getpAttendsNursery() {
         return infantAllocation.pAttendsNursery;
@@ -645,6 +678,13 @@ public class PopulationParameters {
         return householdProperties.expectedNeighbours;
     }
     public double getHouseholdVisitorLeaveRate() { return householdProperties.visitorLeaveRate; }
+
+    public double getpGoShopping() {
+        return householdProperties.pGoShopping;
+    }
+    public double getpGoRestaurant() {
+        return householdProperties.pGoRestaurant;
+    }
 
     // Person Properties
     public double getpQuarantine() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
@@ -372,7 +372,7 @@ public class PopulationParameters {
         valid = valid && checker.isValid(buildingProperties) && buildingProperties.isValid();
         valid = valid && checker.isValid(infantAllocation) && infantAllocation.isValid();
         valid = valid && checker.isValid(personProperties) && personProperties.isValid();
-        valid = valid && checker.isValid(householdProperties);
+        valid = valid && checker.isValid(householdProperties) && householdProperties.isValid();
         return valid;
     }
 
@@ -678,6 +678,7 @@ public class PopulationParameters {
         return householdProperties.expectedNeighbours;
     }
     public double getHouseholdVisitorLeaveRate() { return householdProperties.visitorLeaveRate; }
+    public void setHouseholdVisitorLeaveRate(double p) { householdProperties.visitorLeaveRate = p; }
 
     public double getpGoShopping() {
         return householdProperties.pGoShopping;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Shifts.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Shifts.java
@@ -36,10 +36,16 @@ public class Shifts {
 
     public Shifts() {
         shifts = new HashMap<>();
+        for (int i = 0; i < 7; i++) {
+            shifts.put(i, new Shift(0,0));
+        }
     }
 
-    public Shifts(Map<Integer, Shift> s) {
-        shifts = s;
+    public Shifts(int s, int e, int... days) {
+        this();
+        for (int i = 0; i < days.length; i++) {
+            shifts.put(days[i], new Shift(s, e));
+        }
     }
 
     public Shift getShift(int day) {
@@ -47,45 +53,21 @@ public class Shifts {
     }
 
     // Common shift patterns
-    private static Shifts nineFive;
-    public static Shifts getNineFive () {
-        if (nineFive == null) {
-            nineFive = new Shifts();
-            Shift s = new Shift(9, 17);
-            for (int i = 0; i < 7; i++) {
-                nineFive.shifts.put(i, s);
-            }
+    private static Shifts nineFiveFiveDays;
+    public static Shifts nineFiveFiveDays() {
+        if (nineFiveFiveDays == null) {
+            nineFiveFiveDays = new Shifts(9, 17, 0, 1, 2, 3, 4);
         }
-        return nineFive;
+        return nineFiveFiveDays;
     }
 
     private static Shifts schoolTimes;
-    public static Shifts getSchoolTimes() {
+    public static Shifts schoolTimes() {
         if (schoolTimes == null) {
-            schoolTimes = new Shifts();
-            Shift s = new Shift(9, 15);
-            for (int i = 0; i < 5; i++) {
-                schoolTimes.shifts.put(i, s);
-            }
+            schoolTimes = new Shifts(9,17, 0, 1, 2, 3, 4);
 
-            s = new Shift(0, 0);
-            for (int i = 5; i < 7; i++) {
-                schoolTimes.shifts.put(i, s);
-            }
         }
         return schoolTimes;
     }
-    
-    // For backwards compatibility only
-    private static Shifts allTimes;
-    public static Shifts getAllTimes () {
-        if (allTimes == null) {
-            allTimes = new Shifts();
-            Shift s = new Shift(0, 23);
-            for (int i = 0; i < 7; i++) {
-                allTimes.shifts.put(i, s);
-            }
-        }
-        return allTimes;
-    }
+
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Shifts.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Shifts.java
@@ -22,6 +22,14 @@ public class Shifts {
         public void setStart(int start) {
             this.start = start;
         }
+
+        public int getEnd() {
+            return end;
+        }
+
+        public void setEnd(int end) {
+            this.end = end;
+        }
     }
 
     private Map<Integer, Shift> shifts;
@@ -45,7 +53,7 @@ public class Shifts {
             nineFive = new Shifts();
             Shift s = new Shift(9, 17);
             for (int i = 0; i < 7; i++) {
-                nineFive.shifts.put(0, s);
+                nineFive.shifts.put(i, s);
             }
         }
         return nineFive;
@@ -57,7 +65,12 @@ public class Shifts {
             schoolTimes = new Shifts();
             Shift s = new Shift(9, 15);
             for (int i = 0; i < 5; i++) {
-                schoolTimes.shifts.put(0, s);
+                schoolTimes.shifts.put(i, s);
+            }
+
+            s = new Shift(0, 0);
+            for (int i = 5; i < 7; i++) {
+                schoolTimes.shifts.put(i, s);
             }
         }
         return schoolTimes;
@@ -70,7 +83,7 @@ public class Shifts {
             allTimes = new Shifts();
             Shift s = new Shift(0, 23);
             for (int i = 0; i < 7; i++) {
-                allTimes.shifts.put(0, s);
+                allTimes.shifts.put(i, s);
             }
         }
         return allTimes;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Shifts.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Shifts.java
@@ -1,0 +1,78 @@
+package uk.co.ramp.covid.simulation.population;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Class to track the shifts people are at their primary places (i.e. nursery visit times are also shifts) */
+public class Shifts {
+
+    public static class Shift {
+        private int start;
+        private int end;
+
+        public Shift(int s, int e) {
+            start = s;
+            end = e;
+        }
+
+        public int getStart() {
+            return start;
+        }
+
+        public void setStart(int start) {
+            this.start = start;
+        }
+    }
+
+    private Map<Integer, Shift> shifts;
+
+    public Shifts() {
+        shifts = new HashMap<>();
+    }
+
+    public Shifts(Map<Integer, Shift> s) {
+        shifts = s;
+    }
+
+    public Shift getShift(int day) {
+        return shifts.get(day);
+    }
+
+    // Common shift patterns
+    private static Shifts nineFive;
+    public static Shifts getNineFive () {
+        if (nineFive == null) {
+            nineFive = new Shifts();
+            Shift s = new Shift(9, 17);
+            for (int i = 0; i < 7; i++) {
+                nineFive.shifts.put(0, s);
+            }
+        }
+        return nineFive;
+    }
+
+    private static Shifts schoolTimes;
+    public static Shifts getSchoolTimes() {
+        if (schoolTimes == null) {
+            schoolTimes = new Shifts();
+            Shift s = new Shift(9, 15);
+            for (int i = 0; i < 5; i++) {
+                schoolTimes.shifts.put(0, s);
+            }
+        }
+        return schoolTimes;
+    }
+    
+    // For backwards compatibility only
+    private static Shifts allTimes;
+    public static Shifts getAllTimes () {
+        if (allTimes == null) {
+            allTimes = new Shifts();
+            Shift s = new Shift(0, 23);
+            for (int i = 0; i < 7; i++) {
+                allTimes.shifts.put(0, s);
+            }
+        }
+        return allTimes;
+    }
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/util/RoundRobinAllocator.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/RoundRobinAllocator.java
@@ -1,0 +1,34 @@
+package uk.co.ramp.covid.simulation.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Simple class to return elements of a container in a round-robin fashion
+ *  Used primarily to assign shifts to workers
+ */
+public class RoundRobinAllocator<T> {
+    private List<T> data;
+    private int next;
+    
+    public RoundRobinAllocator() {
+        data = new ArrayList<>();
+        next = -1;
+    }
+    
+    public void put(T e) {
+        data.add(e);
+        if (next == -1) {
+            next = 0;
+        }
+    }
+    
+    public T getNext() {
+        if (next == -1) {
+            return null;
+        } 
+        
+        T res = data.get(next);
+        next = (next + 1) % data.size();
+        return res;
+    }
+}

--- a/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
@@ -10,6 +10,7 @@ import uk.co.ramp.covid.simulation.population.*;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /** Movement tests do not test a particular class, but check basic assumptions around movement throughout a run */
@@ -17,7 +18,7 @@ public class MovementTest {
 
     Population p;
     int populationSize = 10000;
-    int nHouseholds = 3000;
+    int nHouseholds = 2000;
     int nInfections = 10;
 
     @Before
@@ -176,5 +177,22 @@ public class MovementTest {
         }
     }
 
+    @Test
+    public void openPlacesShouldBeStaffed() {
+        int day = 1;
+        DailyStats s = new DailyStats(day);
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(day, i, s);
 
+            int npeople = 0;
+            for (CommunalPlace place : p.getPlaces().getAllPlaces()) {
+                // i + 1 since the ith timestep has already been (so we are in the next state)
+                if (place.isOpen(day, i + 1)) {
+                    List<Person> staff = place.getStaff(day, i + 1);
+                   assertTrue(staff.size() > 0);
+                }
+            }
+
+        }
+    }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
@@ -1,0 +1,163 @@
+package uk.co.ramp.covid.simulation;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import uk.co.ramp.covid.simulation.io.ParameterReader;
+import uk.co.ramp.covid.simulation.place.*;
+import uk.co.ramp.covid.simulation.population.*;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Movement tests do not test a particular class, but check basic assumptions around movement throughout a run */
+public class MovementTest {
+
+    Population p;
+
+    @Before
+    public void initialiseTestModel() throws ImpossibleAllocationException, IOException {
+        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
+
+        int populationSize = 10000;
+        int nHouseholds = 3000;
+        int nInfections = 10;
+        p = new Population(populationSize, nHouseholds);
+        p.populateHouseholds();
+        p.createMixing();
+        p.allocatePeople();
+        p.seedVirus(nInfections);
+    }
+
+    @Test
+    public void allChildrenGoToSchool() {
+        int day = 1;
+        Set<Child> schooled = new HashSet();
+        DailyStats s = new DailyStats(day);
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(day, i, s);
+            
+            for (School school : p.getPlaces().getSchools()) {
+                for (Person c : school.getPeople()) {
+                    if (c instanceof Child) {
+                        schooled.add( (Child) c);
+                    }
+                }
+            }
+        }
+       
+        int numChildren = 0;
+        for (Person per : p.getAllPeople()) {
+            if (per instanceof Child) {
+                numChildren++;
+            }
+        }
+        
+        assertEquals(numChildren, schooled.size());
+    }
+
+    @Test
+    public void someInfantsGoToNursery() {
+        int day = 1;
+        Set<Infant> nursed = new HashSet();
+        DailyStats s = new DailyStats(day);
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(day, i, s);
+
+            for (Nursery nursery : p.getPlaces().getNurseries()) {
+                for (Person c : nursery.getPeople()) {
+                    if (c instanceof Infant) {
+                        nursed.add( (Infant) c);
+                    }
+                }
+            }
+        }
+
+        // TODO: We can check specifics once we know how many infants go to nursery.
+        // This is not trivial since not all infants who go to nursery will go on day 1.
+        assertTrue(nursed.size() > 0);
+    }
+
+    @Test
+    public void someAdultsGoToWork() {
+        int day = 1;
+        Set<Adult> working = new HashSet();
+        DailyStats s = new DailyStats(day);
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(day, i, s);
+
+            for (CommunalPlace place : p.getPlaces().getAllPlaces()) {
+                for (Person per : place.getPeople()) {
+                    if (per instanceof Adult) {
+                        working.add( (Adult) per);
+                    }
+                }
+            }
+        }
+
+        assertTrue(working.size() > 0);
+    }
+
+    @Test
+    public void someNonWorkersGoShopping() {
+        int day = 1;
+        Set<Person> shopping = new HashSet();
+        DailyStats s = new DailyStats(day);
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(day, i, s);
+
+            for (Shop place : p.getPlaces().getShops()) {
+                for (Person per : place.getPeople()) {
+                    // TODO-FIXME: Technically shop workers can also shop where they work if they are not currently working.
+                    if (per.getPrimaryCommunalPlace() != place) {
+                        shopping.add(per);
+                    }
+                }
+            }
+        }
+
+        assertTrue(shopping.size() > 0);
+    }
+
+    @Test
+    public void someNonWorkersGoSToRestaurants() {
+        int day = 1;
+        Set<Person> eating = new HashSet();
+        DailyStats s = new DailyStats(day);
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(day, i, s);
+
+            for (Restaurant place : p.getPlaces().getRestaurants()) {
+                for (Person per : place.getPeople()) {
+                    // TODO-FIXME: Technically restaurant workers can also eat where they work if they are not currently working.
+                    if (per.getPrimaryCommunalPlace() != place) {
+                        eating.add(per);
+                    }
+                }
+            }
+        }
+
+        assertTrue(eating.size() > 0);
+    }
+
+    @Test
+    public void somePeopleVisitNeighbours() {
+        int day = 1;
+        Set<Person> visiting = new HashSet();
+        DailyStats s = new DailyStats(day);
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(day, i, s);
+
+            for (Household place : p.getPopulation()) {
+                for (Person per : place.getVisitors()) {
+                    visiting.add(per);
+                }
+            }
+        }
+        assertTrue(visiting.size() > 0);
+    }
+
+
+}

--- a/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.*;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -151,7 +150,7 @@ public class MovementTest {
         for (int i = 0; i < 24; i++) {
             p.timeStep(day, i, s);
 
-            for (Household place : p.getPopulation()) {
+            for (Household place : p.getHouseholds()) {
                 visiting.addAll(place.getVisitors());
             }
         }
@@ -170,7 +169,7 @@ public class MovementTest {
                 npeople += place.getPeople().size();
             }
 
-            for (Household hld : p.getPopulation()) {
+            for (Household hld : p.getHouseholds()) {
                 npeople += hld.getPeople().size();
             }
             assertEquals(populationSize, npeople);

--- a/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
@@ -37,7 +37,7 @@ public class MovementTest {
         Set<Child> schooled = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, false, s);
+            p.timeStep(day, i, s);
             
             for (School school : p.getPlaces().getSchools()) {
                 for (Person c : school.getPeople()) {
@@ -64,7 +64,7 @@ public class MovementTest {
         Set<Infant> nursed = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, false, s);
+            p.timeStep(day, i, s);
 
             for (Nursery nursery : p.getPlaces().getNurseries()) {
                 for (Person c : nursery.getPeople()) {
@@ -86,7 +86,7 @@ public class MovementTest {
         Set<Adult> working = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, false, s);
+            p.timeStep(day, i, s);
 
             for (CommunalPlace place : p.getPlaces().getAllPlaces()) {
                 for (Person per : place.getPeople()) {
@@ -106,7 +106,7 @@ public class MovementTest {
         Set<Person> shopping = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, false, s);
+            p.timeStep(day, i, s);
 
             for (Shop place : p.getPlaces().getShops()) {
                 for (Person per : place.getPeople()) {
@@ -127,7 +127,7 @@ public class MovementTest {
         Set<Person> eating = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, false, s);
+            p.timeStep(day, i, s);
 
             for (Restaurant place : p.getPlaces().getRestaurants()) {
                 for (Person per : place.getPeople()) {
@@ -148,7 +148,7 @@ public class MovementTest {
         Set<Person> visiting = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, false, s);
+            p.timeStep(day, i, s);
 
             for (Household place : p.getHouseholds()) {
                 visiting.addAll(place.getVisitors());
@@ -162,7 +162,7 @@ public class MovementTest {
         int day = 1;
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, false, s);
+            p.timeStep(day, i, s);
 
             int npeople = 0;
             for (Place place : p.getPlaces().getAllPlaces()) {

--- a/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
@@ -37,7 +37,7 @@ public class MovementTest {
         Set<Child> schooled = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, s);
+            p.timeStep(day, i, false, s);
             
             for (School school : p.getPlaces().getSchools()) {
                 for (Person c : school.getPeople()) {
@@ -64,7 +64,7 @@ public class MovementTest {
         Set<Infant> nursed = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, s);
+            p.timeStep(day, i, false, s);
 
             for (Nursery nursery : p.getPlaces().getNurseries()) {
                 for (Person c : nursery.getPeople()) {
@@ -86,7 +86,7 @@ public class MovementTest {
         Set<Adult> working = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, s);
+            p.timeStep(day, i, false, s);
 
             for (CommunalPlace place : p.getPlaces().getAllPlaces()) {
                 for (Person per : place.getPeople()) {
@@ -106,7 +106,7 @@ public class MovementTest {
         Set<Person> shopping = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, s);
+            p.timeStep(day, i, false, s);
 
             for (Shop place : p.getPlaces().getShops()) {
                 for (Person per : place.getPeople()) {
@@ -127,7 +127,7 @@ public class MovementTest {
         Set<Person> eating = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, s);
+            p.timeStep(day, i, false, s);
 
             for (Restaurant place : p.getPlaces().getRestaurants()) {
                 for (Person per : place.getPeople()) {
@@ -148,7 +148,7 @@ public class MovementTest {
         Set<Person> visiting = new HashSet();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, s);
+            p.timeStep(day, i, false, s);
 
             for (Household place : p.getHouseholds()) {
                 visiting.addAll(place.getVisitors());
@@ -162,7 +162,7 @@ public class MovementTest {
         int day = 1;
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
-            p.timeStep(day, i, s);
+            p.timeStep(day, i, false, s);
 
             int npeople = 0;
             for (Place place : p.getPlaces().getAllPlaces()) {

--- a/src/test/java/uk/co/ramp/covid/simulation/io/ParameterReaderTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/io/ParameterReaderTest.java
@@ -92,6 +92,11 @@ public class ParameterReaderTest {
         assertEquals(0.25, PopulationParameters.get().getpOfficeSmall(), EPSILON);
         assertEquals(0.4, PopulationParameters.get().getpOfficeMed(), EPSILON);
         assertEquals(0.35, PopulationParameters.get().getpOfficeLarge(), EPSILON);
+
+        assertEquals(0.4, PopulationParameters.get().getpLeaveRestaurant(), EPSILON);
+        assertEquals(0.5, PopulationParameters.get().getpLeaveShop(), EPSILON);
+        assertEquals(0.01786, PopulationParameters.get().getpGoShopping(), EPSILON);
+        assertEquals(0.01190, PopulationParameters.get().getpGoRestaurant(), EPSILON);
     }
 
     @After

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -9,6 +9,7 @@ import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.Adult;
 import uk.co.ramp.covid.simulation.population.Person;
+import uk.co.ramp.covid.simulation.population.PopulationParameters;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 import static org.junit.Assert.assertEquals;
@@ -79,41 +80,17 @@ public class HouseholdTest {
     }
 
     @Test
-    public void testCycleHouse() {
-        int expSize = 3;
-        DailyStats s = new DailyStats(0);
-        assertEquals("Unexpected household size", expSize, household.cycleHouse(s).size());
-    }
-
-    @Test
-    public void testWelcomeNeighbours() {
-        Household newHouse = new Household(Household.HouseholdType.ADULT, null);
-        Person p1 = new Adult();
-        Person p2 = new Adult();
-        newHouse.addInhabitant(p1);
-        newHouse.addInhabitant(p2);
-        household.welcomeNeighbours(newHouse);
-        int expSize = 2;
-        assertEquals("Unexpected household size", expSize, household.getVisitors().size());
-
-    }
-    
-
-    @Test
     public void testSendNeighboursHome() {
-        Household newHouse = new Household(Household.HouseholdType.ADULT, null);
+        PopulationParameters.get().setHouseholdVisitorLeaveRate(1.0);
+        Household h = new Household(Household.HouseholdType.ADULT, null);
         Person p1 = new Adult();
-        newHouse.addInhabitant(p1);
-        p1.setHome(newHouse);
-        household.welcomeNeighbours(newHouse);
-        int expSize = 1;
-        assertEquals("Unexpected number of visitors", expSize, household.sendNeighboursHome(0,0));
-    }
+        
+        p1.setHome(household);
+        h.addPersonNext(p1);
+        h.stepPeople();
 
-    @Test
-    public void testShoppingTrip() {
-        int expPeople = 3;
-        assertEquals("Unexpected number of people shopping", expPeople, household.shoppingTrip().size());
+        int expSize = 1;
+        assertEquals("Unexpected number of visitors", expSize, h.sendNeighboursHome(0,0));
     }
 
     @Test

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -99,6 +99,7 @@ public class HouseholdTest {
 
     }
     
+
     @Test
     public void testSendNeighboursHome() {
         Household newHouse = new Household(Household.HouseholdType.ADULT, null);
@@ -107,7 +108,7 @@ public class HouseholdTest {
         p1.setHome(newHouse);
         household.welcomeNeighbours(newHouse);
         int expSize = 1;
-        assertEquals("Unexpected number of visitors", expSize, household.sendNeighboursHome());
+        assertEquals("Unexpected number of visitors", expSize, household.sendNeighboursHome(0,0));
     }
 
     @Test

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -30,16 +30,16 @@ public class HouseholdTest {
     public void initialise() throws JsonParseException, IOException {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         RNG.seed(123);
-        household = new Household(Household.HouseholdType.ADULT);
+        household = new Household(Household.HouseholdType.ADULT, null);
         Person p1 = new Adult();
         Person p2 = new Adult();
         Person p3 = new Adult();
         household.addInhabitant(p1);
         household.addInhabitant(p2);
         household.addInhabitant(p3);
-        household2 = new Household(Household.HouseholdType.ADULT);
-        household3 = new Household(Household.HouseholdType.ADULT);
-        household4 = new Household(Household.HouseholdType.ADULT);
+        household2 = new Household(Household.HouseholdType.ADULT, null);
+        household3 = new Household(Household.HouseholdType.ADULT, null);
+        household4 = new Household(Household.HouseholdType.ADULT, null);
 
     }
 
@@ -88,7 +88,7 @@ public class HouseholdTest {
 
     @Test
     public void testWelcomeNeighbours() {
-        Household newHouse = new Household(Household.HouseholdType.ADULT);
+        Household newHouse = new Household(Household.HouseholdType.ADULT, null);
         Person p1 = new Adult();
         Person p2 = new Adult();
         newHouse.addInhabitant(p1);
@@ -101,7 +101,7 @@ public class HouseholdTest {
     
     @Test
     public void testSendNeighboursHome() {
-        Household newHouse = new Household(Household.HouseholdType.ADULT);
+        Household newHouse = new Household(Household.HouseholdType.ADULT, null);
         Person p1 = new Adult();
         newHouse.addInhabitant(p1);
         p1.setHome(newHouse);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -56,6 +56,7 @@ public class RestaurantTest {
 
     @Test
     public void testSendHome() {
+        PopulationParameters.get().setpLeaveRestaurant(1.0);
         int time = restaurant.times.getClose() - 1;
         int left = restaurant.sendHome(time, 0);
         int expPeople = 2;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -56,8 +56,8 @@ public class RestaurantTest {
 
     @Test
     public void testSendHome() {
-        int time = restaurant.endTime - 1;
-        int left = restaurant.sendHome(time);
+        int time = restaurant.times.getClose() - 1;
+        int left = restaurant.sendHome(time, 0);
         int expPeople = 2;
         assertEquals("Unexpected number of people sent home from restaurant", expPeople, left);
     }

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -30,8 +30,8 @@ public class RestaurantTest {
         restaurant = new Restaurant();
         p1 = new Adult();
         p2 = new Pensioner();
-        Household h1 = new Household(Household.HouseholdType.ADULT);
-        Household h2 = new Household(Household.HouseholdType.PENSIONER);
+        Household h1 = new Household(Household.HouseholdType.ADULT, null);
+        Household h2 = new Household(Household.HouseholdType.PENSIONER, null);
         p1.setHome(h1);
         p2.setHome(h2);
         restaurant.people.add(p1);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -29,8 +29,8 @@ public class ShopTest {
         shop = new Shop();
         p1 = new Adult();
         p2 = new Pensioner();
-        Household h1 = new Household(Household.HouseholdType.ADULT);
-        Household h2 = new Household(Household.HouseholdType.PENSIONER);
+        Household h1 = new Household(Household.HouseholdType.ADULT, null);
+        Household h2 = new Household(Household.HouseholdType.PENSIONER, null);
         p1.setHome(h1);
         p2.setHome(h2);
         shop.people.add(p1);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -55,6 +55,7 @@ public class ShopTest {
 
     @Test
     public void testSendHome() {
+        PopulationParameters.get().setpLeaveShop(1.0);
         int time = shop.times.getClose() - 1;
         int left = shop.sendHome(time, 0);
         int expPeople = 2;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -55,8 +55,8 @@ public class ShopTest {
 
     @Test
     public void testSendHome() {
-        int time = shop.endTime - 1;
-        int left = shop.sendHome(time);
+        int time = shop.times.getClose() - 1;
+        int left = shop.sendHome(time, 0);
         int expPeople = 2;
         assertEquals("Unexpected number of people sent home", expPeople, left);
     }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/AdultTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/AdultTest.java
@@ -18,7 +18,7 @@ public class AdultTest {
         boolean professionSet = false;
         professionSet = professionSet
                      || adult.profession == Adult.Professions.CONSTRUCTION
-                     || adult.isShopWorker()
+                     || adult.profession == Adult.Professions.SHOP
                      || adult.profession == Adult.Professions.HOSPITAL
                      || adult.profession == Adult.Professions.OFFICE
                      || adult.profession == Adult.Professions.RESTAURANT

--- a/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
@@ -42,7 +42,7 @@ public class InfantTest {
 
         List<DailyStats> stats;
         int nDays = 1;
-        stats = p.timeStep(nDays);
+        stats = p.simulate(nDays);
 
         infant.reportInfection(stats.get(0));
         assertEquals("Unexpected number of infant infections", 1, stats.get(0).getInfantInfected());

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
@@ -30,7 +30,7 @@ public class PensionerTest {
 
         List<DailyStats> stats;
         int nDays = 1;
-        stats = p.timeStep(nDays);
+        stats = p.simulate(nDays);
 
         pensioner.reportInfection(stats.get(0));
         assertEquals("Unexpected number of pensioner infections", 1, stats.get(0).getPensionerInfected());

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -247,7 +247,7 @@ public class PopulationTest {
         int nDays = 3;
         p.createMixing();
         p.assignNeighbours();
-        stats = p.timeStep(nDays);
+        stats = p.simulate(nDays);
         assertEquals("Unexpected number of daily stats", nDays, stats.size());
     }
 

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -44,13 +44,13 @@ public class PopulationTest {
 
         // Final population size = initial population size (all people allocated)
         int pop = 0;
-        for (Household h : p.getPopulation()) {
+        for (Household h : p.getHouseholds()) {
            pop += h.getHouseholdSize();
         }
         assertEquals("Sum total household size should equal population size",  populationSize, pop);
 
         // Sanity check households
-        for (Household h : p.getPopulation()){
+        for (Household h : p.getHouseholds()){
             assertTrue("Each household must be assigned at least 1 person", h.getHouseholdSize() > 0);
             switch (h.gethType()) {
                 // Adults only
@@ -139,7 +139,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.CONSTRUCTION;
-        p.getPopulation()[0].addInhabitant(adult);
+        p.getHouseholds().get(0).addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof ConstructionSite);
@@ -151,7 +151,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.HOSPITAL;
-        p.getPopulation()[0].addInhabitant(adult);
+        p.getHouseholds().get(0).addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Hospital);
@@ -163,7 +163,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.OFFICE;
-        p.getPopulation()[0].addInhabitant(adult);
+        p.getHouseholds().get(0).addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Office);
@@ -175,7 +175,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.RESTAURANT;
-        p.getPopulation()[0].addInhabitant(adult);
+        p.getHouseholds().get(0).addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Restaurant);
@@ -187,7 +187,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.TEACHER;
-        p.getPopulation()[0].addInhabitant(adult);
+        p.getHouseholds().get(0).addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof School);
@@ -199,7 +199,7 @@ public class PopulationTest {
         p.createMixing();
         Adult adult = new Adult();
         adult.profession = Adult.Professions.SHOP;
-        p.getPopulation()[0].addInhabitant(adult);
+        p.getHouseholds().get(0).addInhabitant(adult);
         adult.allocateCommunalPlace(p.getPlaces());
         CommunalPlace cp = adult.getPrimaryCommunalPlace();
         assertTrue("Unexpected primary communal place", cp instanceof Shop);
@@ -231,8 +231,8 @@ public class PopulationTest {
 
         //loop for each household and check neighbour list is not null
         for (int i = 0; i < p.getnHousehold(); i++) {
-            assertNotNull("Null neighbour list", p.getPopulation()[i].nNeighbours());
-            totalNeighbours += p.getPopulation()[i].nNeighbours();
+            assertNotNull("Null neighbour list", p.getHouseholds().get(i).nNeighbours());
+            totalNeighbours += p.getHouseholds().get(i).nNeighbours();
         }
 
         //Get the mean number of neighbours per household and compare against the expected

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -330,4 +330,14 @@ public class PopulationTest {
             assertTrue("Nursery should be a key premises", n.isKeyPremises());
         }
     }
+
+    // TODO: This runs sucessfully if the whole harness is run, but not if only this test is run. It's not cler why.
+    @Test
+    public void allPlacesStaffed() {
+        p.createMixing();
+        p.allocatePeople();
+        for (CommunalPlace q : p.getPlaces().getAllPlaces()) {
+            assertTrue("Place not fully staffed, nStaff: " + q.getnStaff(), q.isFullyStaffed());
+        }
+    }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -281,7 +281,7 @@ public class PopulationTest {
         p.createMixing();
         p.assignNeighbours();
         p.setLockdown(startLockdown, endLockdown, socialDist);
-        stats = p.timeStep(nDays);
+        stats = p.simulate(nDays);
         assertFalse("Unexpectedly still in lockdown", p.isLockdown());
     }
 
@@ -295,7 +295,7 @@ public class PopulationTest {
         p.createMixing();
         p.assignNeighbours();
         p.setLockdown(start, end, socialDist);
-        stats = p.timeStep(nDays);
+        stats = p.simulate(nDays);
         assertTrue("Unexpectedly not in lockdown", p.isLockdown());
         assertTrue("Restaurants not in lockdown", p.isrLockdown());
     }
@@ -322,7 +322,7 @@ public class PopulationTest {
         p.assignNeighbours();
         p.setLockdown(startLockdown, endLockdown, socialDist);
         p.setSchoolLockdown(startLockdown, endLockdown - 2, socialDist);
-        stats = p.timeStep(nDays);
+        stats = p.simulate(nDays);
         for (School s : p.getPlaces().getSchools()) {
             assertTrue("School should be a key premises", s.isKeyPremises());
         }

--- a/src/test/java/uk/co/ramp/covid/simulation/util/RoundRobinAllocatorTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/util/RoundRobinAllocatorTest.java
@@ -1,0 +1,49 @@
+package uk.co.ramp.covid.simulation.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RoundRobinAllocatorTest {
+
+    @Test
+    public void testPutGet() {
+        RoundRobinAllocator<Integer> r = new RoundRobinAllocator<>();
+        r.put(0);
+        int x = r.getNext();
+        assertEquals(0, x);
+    }
+
+    @Test
+    public void testGetNothing() {
+        RoundRobinAllocator<Integer> r = new RoundRobinAllocator<>();
+        Integer x = r.getNext();
+        assertEquals(null, x);
+    }
+
+    @Test
+    public void testPutGetSingleElem() {
+        RoundRobinAllocator<Integer> r = new RoundRobinAllocator<>();
+        r.put(0);
+        int x = r.getNext();
+        assertEquals(0, x);
+
+        int y = r.getNext();
+        assertEquals(0, y);
+    }
+
+    @Test
+    public void testPutGetTwoElems() {
+        RoundRobinAllocator<Integer> r = new RoundRobinAllocator<>();
+        r.put(0);
+        r.put(1);
+        int x = r.getNext();
+        assertEquals(0, x);
+
+        int y = r.getNext();
+        assertEquals(1, y);
+
+        int z = r.getNext();
+        assertEquals(0, z);
+    }
+}

--- a/src/test/resources/default_params.json
+++ b/src/test/resources/default_params.json
@@ -114,8 +114,9 @@
             "pShop":0.1,
             "pHospital":0.1,
             "pConstruction":0.1,
-            "pTeacher":0.2,
+            "pTeacher":0.15,
             "pRestaurant":0.1,
+            "pNursery":0.05,
             "pUnemployed":0.2,
             "sizeAllocation":{
                 "pSmall": 0.2,

--- a/src/test/resources/default_params.json
+++ b/src/test/resources/default_params.json
@@ -130,7 +130,9 @@
             "pHospitalKey":0,
             "pConstructionSiteKey":0.5,
             "pOfficeKey":0.5,
-            "pShopKey":0.5
+            "pShopKey":0.5,
+            "pLeaveShop": 0.5,
+            "pLeaveRestaurant": 0.4
         },
         "infantAllocation":{
             "pAttendsNursery":0.5
@@ -138,7 +140,9 @@
         "householdProperties":{
             "visitorLeaveRate":0.5,
             "neighbourVisitFreq":0.006,
-            "expectedNeighbours":3
+            "expectedNeighbours":3,
+            "pGoShopping":0.01786,
+            "pGoRestaurant": 0.01190
         },
         "personProperties":{
             "pTransmission":0.45,

--- a/src/test/resources/test_params.json
+++ b/src/test/resources/test_params.json
@@ -122,7 +122,9 @@
             "pHospitalKey":0.1,
             "pConstructionSiteKey":0.6,
             "pOfficeKey":0.9,
-            "pShopKey":0.2
+            "pShopKey":0.2,
+            "pLeaveShop": 0.5,
+            "pLeaveRestaurant": 0.4
         },
         "infantAllocation":{
             "pAttendsNursery":0.8
@@ -130,7 +132,9 @@
         "householdProperties":{
             "neighbourVisitFreq":0.05,
             "visitorLeaveRate":0.8,
-            "expectedNeighbours":2
+            "expectedNeighbours":2,
+            "pGoShopping":0.01786,
+            "pGoRestaurant": 0.01190
         },
         "personProperties":{
             "pTransmission":0.9,

--- a/src/test/resources/test_params.json
+++ b/src/test/resources/test_params.json
@@ -106,9 +106,10 @@
             "pShop":0.2,
             "pHospital":0.2,
             "pConstruction":0.1,
-            "pTeacher":0.1,
+            "pTeacher":0.05,
             "pRestaurant":0.2,
             "pUnemployed":0.1,
+            "pNursery":0.05,
             "sizeAllocation":{
               "pSmall": 0.2,
               "pMed": 0.3,


### PR DESCRIPTION
This PR add opening times to places, shifts to people, and overhauls the movement of people through places.

In particular movement is a 2 step approach - first we move everyone to a temporary buffer, then we commit this after everyone has moved. This makes it much easier to avoid ordering effects (e.g. you can no longer move home and then go to work in a single timestep).