### PR TITLE
Reduce warning messages

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/DailyStats.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/DailyStats.java
@@ -3,7 +3,6 @@ package uk.co.ramp.covid.simulation;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.population.*;
 
 /** DailyStatis accumluates statistics, e.g. healthy/dead, for a particular day */

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -61,7 +61,7 @@ public abstract class CommunalPlace extends Place {
 
     /** Move everyone based on their shift patterns */
     public void moveShifts(int day, int hour, boolean lockdown) {
-        List<Person> left = new ArrayList();
+        List<Person> left = new ArrayList<>();
         for (Person p : people) {
             if (!p.worksNextHour(this, day, hour, lockdown)) {
                 p.returnHome();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -5,9 +5,6 @@
 package uk.co.ramp.covid.simulation.place;
 
 import org.apache.commons.math3.random.RandomDataGenerator;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.Shifts;
 import uk.co.ramp.covid.simulation.util.RNG;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -15,7 +15,7 @@ import java.util.List;
 public abstract class CommunalPlace extends Place {
 
     public enum Size {
-        SMALL, MED, LARGE, UNKNOWN
+        SMALL, MED, LARGE
     }
     
     protected Size size;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
@@ -7,10 +7,6 @@ import uk.co.ramp.covid.simulation.population.Shifts;
 
 public class ConstructionSite extends CommunalPlace {
 
-    public ConstructionSite() {
-        this(Size.UNKNOWN);
-    }
-    
     public ConstructionSite(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpConstructionSiteTrans();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -10,10 +10,6 @@ public class Hospital extends CommunalPlace {
     
     private RoundRobinAllocator<Shifts> shifts;
 
-    public Hospital() {
-        this(Size.UNKNOWN);
-    }
-
     public Hospital(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpHospitalTrans();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -184,7 +184,7 @@ public class Household extends Place {
     }
 
     private void moveNeighbour(int day, int hour) {
-        List<Person> left = new ArrayList();
+        List<Person> left = new ArrayList<>();
 
         for (Household n : getNeighbours()) {
             if (n.isIsolating()) {
@@ -207,7 +207,7 @@ public class Household extends Place {
     }
 
     private void moveShop(int day, int hour, boolean lockdown) {
-        List<Person> left = new ArrayList();
+        List<Person> left = new ArrayList<>();
 
         double visitProb = PopulationParameters.get().getpGoShopping();
         if (lockdown) {
@@ -243,7 +243,7 @@ public class Household extends Place {
     }
 
     private void moveRestaurant(int day, int hour) {
-        List<Person> left = new ArrayList();
+        List<Person> left = new ArrayList<>();
 
         double visitProb = PopulationParameters.get().getpGoRestaurant();
 
@@ -274,7 +274,7 @@ public class Household extends Place {
     }
 
     private void moveShift(int day, int hour, boolean lockdown) {
-        List<Person> left = new ArrayList();
+        List<Person> left = new ArrayList<>();
         for (Person p : getInhabitants()) {
             if (p.worksNextHour(p.getPrimaryCommunalPlace(), day, hour, lockdown)) {
                 if (!p.getQuarantine()) {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
@@ -7,10 +7,6 @@ import uk.co.ramp.covid.simulation.population.Shifts;
 
 public class Nursery extends CommunalPlace {
 
-    public Nursery() {
-        this(Size.UNKNOWN);
-    }
-
     public Nursery(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpNurseryTrans();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -7,11 +7,6 @@ import uk.co.ramp.covid.simulation.population.Shifts;
 
 public class Office extends CommunalPlace {
 
-    public Office() {
-        this(Size.UNKNOWN);
-    }
-
-
     public Office(Size s)  {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpOfficeTrans();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -75,7 +75,7 @@ public abstract class Place {
         // Anyone who didn't move should remain.
         nextPeople.addAll(people);
         people = nextPeople;
-        nextPeople = new ArrayList();
+        nextPeople = new ArrayList<>();
     }
 
     public List<Person> sendFamilyHome(Person p, CommunalPlace place, int day, int hour) {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -6,9 +6,7 @@ import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public abstract class Place {
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -13,10 +13,6 @@ public class Restaurant extends CommunalPlace {
 
     private RoundRobinAllocator<Shifts> shifts;
 
-    public Restaurant() {
-        this(Size.UNKNOWN);
-    }
-    
     public Restaurant(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() * PopulationParameters.get().getpRestaurantTrans();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -6,9 +6,6 @@ import uk.co.ramp.covid.simulation.population.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.Shifts;
 
 public class School extends CommunalPlace {
-    public School() {
-        this(Size.UNKNOWN);
-    }
 
     public School(Size s) {
         super(s);

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -25,7 +25,7 @@ public class Shop extends CommunalPlace {
     }
     
     private void setOpeningHours() {
-        shifts = new RoundRobinAllocator();
+        shifts = new RoundRobinAllocator<>();
         if (size == Size.SMALL) {
             times = OpeningTimes.nineFiveAllWeek();
             shifts.put(new Shifts(9,17, 0, 1, 2));

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -12,10 +12,6 @@ public class Shop extends CommunalPlace {
     
     private RoundRobinAllocator<Shifts> shifts;
 
-    public Shop() {
-        this(Size.UNKNOWN);
-    }
-
     public Shop(Size s) {
         super(s);
         transProb = PopulationParameters.get().getpBaseTrans() *  PopulationParameters.get().getpShopTrans();

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
@@ -71,6 +71,9 @@ public class Adult extends Person {
             case RESTAURANT: {
                 primaryPlace = p.getRandomRestaurant();
             } break;
+            case NONE: {
+                // do nothing
+            }
         }
         if (primaryPlace != null) {
             setPrimaryPlace(primaryPlace);

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
@@ -2,11 +2,9 @@ package uk.co.ramp.covid.simulation.population;
 
 import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.util.ProbabilityDistribution;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
@@ -201,7 +201,7 @@ public class Places {
     }
 
     public void createNOffices(int n) {
-        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution<>();
         p.add(PopulationParameters.get().getpOfficeSmall(), CommunalPlace.Size.SMALL);
         p.add(PopulationParameters.get().getpOfficeMed(), CommunalPlace.Size.MED);
         p.add(PopulationParameters.get().getpOfficeLarge(), CommunalPlace.Size.LARGE);
@@ -209,7 +209,7 @@ public class Places {
     }
 
     public void createNHospitals(int n) {
-        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution<>();
         p.add(PopulationParameters.get().getpHospitalSmall(), CommunalPlace.Size.SMALL);
         p.add(PopulationParameters.get().getpHospitalMed(), CommunalPlace.Size.MED);
         p.add(PopulationParameters.get().getpHospitalLarge(), CommunalPlace.Size.LARGE);
@@ -217,14 +217,14 @@ public class Places {
     }
 
     public void createNSchools(int n) {
-        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution<>();
         p.add(PopulationParameters.get().getpSchoolSmall(), CommunalPlace.Size.SMALL);
         p.add(PopulationParameters.get().getpSchoolMed(), CommunalPlace.Size.MED);
         p.add(PopulationParameters.get().getpSchoolLarge(), CommunalPlace.Size.LARGE);
         createNGeneric(s -> new School(s), n, p, schools);
     }
     public void createNNurseries(int n) {
-        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution<>();
         p.add(PopulationParameters.get().getpNurserySmall(), CommunalPlace.Size.SMALL);
         p.add(PopulationParameters.get().getpNurseryMed(), CommunalPlace.Size.MED);
         p.add(PopulationParameters.get().getpNurseryLarge(), CommunalPlace.Size.LARGE);
@@ -232,7 +232,7 @@ public class Places {
     }
 
     public void createNRestaurants(int n) {
-        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution<>();
         p.add(PopulationParameters.get().getpRestaurantSmall(), CommunalPlace.Size.SMALL);
         p.add(PopulationParameters.get().getpRestaurantMed(), CommunalPlace.Size.MED);
         p.add(PopulationParameters.get().getpRestaurantLarge(), CommunalPlace.Size.LARGE);
@@ -240,7 +240,7 @@ public class Places {
     }
 
     public void createNShops(int n) {
-        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution<>();
         p.add(PopulationParameters.get().getpShopSmall(), CommunalPlace.Size.SMALL);
         p.add(PopulationParameters.get().getpShopMed(), CommunalPlace.Size.MED);
         p.add(PopulationParameters.get().getpShopLarge(), CommunalPlace.Size.LARGE);
@@ -248,7 +248,7 @@ public class Places {
     }
 
     public void createNConstructionSites(int n) {
-        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution();
+        ProbabilityDistribution<CommunalPlace.Size> p = new ProbabilityDistribution<>();
         p.add(PopulationParameters.get().getpConstructionSiteSmall(), CommunalPlace.Size.SMALL);
         p.add(PopulationParameters.get().getpConstructionSiteMed(), CommunalPlace.Size.MED);
         p.add(PopulationParameters.get().getpConstructionSiteLarge(), CommunalPlace.Size.LARGE);

--- a/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/PopulationParameters.java
@@ -1,6 +1,5 @@
 package uk.co.ramp.covid.simulation.population;
 
-import org.apache.commons.math3.random.RandomDataGenerator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;

--- a/src/main/java/uk/co/ramp/covid/simulation/util/ProbabilityDistribution.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/ProbabilityDistribution.java
@@ -1,9 +1,6 @@
 package uk.co.ramp.covid.simulation.util;
 
 import org.apache.commons.math3.random.RandomDataGenerator;
-import uk.co.ramp.covid.simulation.RunModel;
-import uk.co.ramp.covid.simulation.place.Household;
-import uk.co.ramp.covid.simulation.population.PopulationParameters;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/uk/co/ramp/covid/simulation/util/ProbabilityDistribution.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/ProbabilityDistribution.java
@@ -30,7 +30,7 @@ public class ProbabilityDistribution<T> {
     private final RandomDataGenerator rng;
 
     public ProbabilityDistribution() {
-        pmap = new ArrayList();
+        pmap = new ArrayList<>();
         totalProb = 0.0;
         this.rng = RNG.get();
     }

--- a/src/test/java/uk/co/ramp/covid/simulation/CovidTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/CovidTest.java
@@ -1,18 +1,15 @@
 package uk.co.ramp.covid.simulation;
 
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.Household;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class CovidTest {
 

--- a/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
@@ -184,7 +184,6 @@ public class MovementTest {
         for (int i = 0; i < 24; i++) {
             p.timeStep(day, i, s);
 
-            int npeople = 0;
             for (CommunalPlace place : p.getPlaces().getAllPlaces()) {
                 // i + 1 since the ith timestep has already been (so we are in the next state)
                 if (place.isOpen(day, i + 1)) {
@@ -197,7 +196,6 @@ public class MovementTest {
     }
     
     private void doesNotGoOut(Household iso, List<Person> isolating) {
-        int npeople = 0;
         for (CommunalPlace place : p.getPlaces().getAllPlaces()) {
             for (Person per : isolating) {
                 assertFalse(place.getPeople().contains(per));

--- a/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
@@ -34,7 +34,7 @@ public class MovementTest {
     @Test
     public void allChildrenGoToSchool() {
         int day = 1;
-        Set<Child> schooled = new HashSet();
+        Set<Child> schooled = new HashSet<>();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
             p.timeStep(day, i, s);
@@ -61,7 +61,7 @@ public class MovementTest {
     @Test
     public void someInfantsGoToNursery() {
         int day = 1;
-        Set<Infant> nursed = new HashSet();
+        Set<Infant> nursed = new HashSet<>();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
             p.timeStep(day, i, s);
@@ -83,7 +83,7 @@ public class MovementTest {
     @Test
     public void someAdultsGoToWork() {
         int day = 1;
-        Set<Adult> working = new HashSet();
+        Set<Adult> working = new HashSet<>();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
             p.timeStep(day, i, s);
@@ -103,7 +103,7 @@ public class MovementTest {
     @Test
     public void someNonWorkersGoShopping() {
         int day = 1;
-        Set<Person> shopping = new HashSet();
+        Set<Person> shopping = new HashSet<>();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
             p.timeStep(day, i, s);
@@ -124,7 +124,7 @@ public class MovementTest {
     @Test
     public void someNonWorkersGoSToRestaurants() {
         int day = 1;
-        Set<Person> eating = new HashSet();
+        Set<Person> eating = new HashSet<>();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
             p.timeStep(day, i, s);
@@ -145,7 +145,7 @@ public class MovementTest {
     @Test
     public void somePeopleVisitNeighbours() {
         int day = 1;
-        Set<Person> visiting = new HashSet();
+        Set<Person> visiting = new HashSet<>();
         DailyStats s = new DailyStats(day);
         for (int i = 0; i < 24; i++) {
             p.timeStep(day, i, s);

--- a/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
@@ -9,6 +9,7 @@ import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -33,6 +34,7 @@ public class MovementTest {
 
     @Test
     public void allChildrenGoToSchool() {
+        RNG.seed(0);
         int day = 1;
         Set<Child> schooled = new HashSet<>();
         DailyStats s = new DailyStats(day);
@@ -227,6 +229,7 @@ public class MovementTest {
 
     @Test
     public void stopIsolatingAfterTimerExpires() {
+        RNG.seed(0);
         int day = 1;
         int daysIsolated = 2;
         DailyStats s = new DailyStats(day);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
@@ -11,7 +11,6 @@ import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.Model;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
@@ -27,7 +27,7 @@ public class ConstructionSiteTest {
 
     @Test
     public void testConstructionSiteTransProb() throws JsonParseException {
-        ConstructionSite constructionSite = new ConstructionSite();
+        ConstructionSite constructionSite = new ConstructionSite(CommunalPlace.Size.MED);
         double expProb = PopulationParameters.get().getpBaseTrans() * 10d / (5000d / 100d);
         double delta = 0.01;
         assertEquals("Unexpected construction site TransProb", expProb, constructionSite.transProb, delta);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -9,7 +9,6 @@ import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -35,7 +35,6 @@ public class HospitalTest {
     @Test
     public void testHospitalWorkers() throws ImpossibleAllocationException, ImpossibleWorkerDistributionException {
         int populationSize = 10000;
-        int nHouseholds = 2000;
         int nInfections = 10;
 
         Population p = new Population(populationSize);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -25,7 +25,7 @@ public class HospitalTest {
 
     @Test
     public void testHospitalTransProb() throws JsonParseException {
-        Hospital hospital = new Hospital();
+        Hospital hospital = new Hospital(CommunalPlace.Size.MED);
         double expProb = PopulationParameters.get().getpBaseTrans() * 15d / (5000d / 10d);
         double delta = 0.01;
         assertEquals("Unexpected hospital TransProb", expProb, hospital.transProb, delta);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -5,12 +5,10 @@ import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 
-import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.Adult;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
@@ -34,7 +34,6 @@ public class NurseryTest {
     @Test
     public void testNurseryWorkers() throws ImpossibleAllocationException, ImpossibleWorkerDistributionException {
         int populationSize = 10000;
-        int nHouseholds = 2000;
         int nInfections = 10;
 
         Population p = new Population(populationSize);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
@@ -8,7 +8,6 @@ import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
@@ -24,7 +24,7 @@ public class NurseryTest {
 
     @Test
     public void testNurseryTransProb() throws JsonParseException {
-        Nursery nursery = new Nursery();
+        Nursery nursery = new Nursery(CommunalPlace.Size.MED);
         double expProb = PopulationParameters.get().getpBaseTrans() * 30d / (34000d / 50d);
         double delta = 0.01;
         assertEquals("Unexpected nursery TransProb", expProb, nursery.transProb, delta);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
@@ -8,7 +8,6 @@ import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
@@ -34,7 +34,6 @@ public class OfficeTest {
     @Test
     public void testOfficeWorkers() throws ImpossibleAllocationException, ImpossibleWorkerDistributionException {
         int populationSize = 10000;
-        int nHouseholds = 2000;
         int nInfections = 10;
 
         Population p = new Population(populationSize);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
@@ -24,7 +24,7 @@ public class OfficeTest {
 
     @Test
     public void testOfficeTransProb() throws JsonParseException {
-        Office office = new Office();
+        Office office = new Office(CommunalPlace.Size.MED);
         double expProb = PopulationParameters.get().getpBaseTrans() * 10d / (10000d / 400d);
         double delta = 0.01;
         assertEquals("Unexpected office TransProb", expProb, office.transProb, delta);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -27,7 +27,7 @@ public class RestaurantTest {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
 
         //Setup a restaurant with 2 people
-        restaurant = new Restaurant();
+        restaurant = new Restaurant(CommunalPlace.Size.MED);
         p1 = new Adult(30, Person.Sex.MALE);
         p2 = new Pensioner(67, Person.Sex.FEMALE);
         Household h1 = new Household(Household.HouseholdType.ADULT, null);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -8,13 +8,10 @@ import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -67,7 +67,6 @@ public class RestaurantTest {
     @Test
     public void testRestaurantWorkers() throws ImpossibleAllocationException, ImpossibleWorkerDistributionException {
         int populationSize = 10000;
-        int nHouseholds = 2000;
         int nInfections = 10;
 
         Population p = new Population(populationSize);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -33,7 +33,6 @@ public class SchoolTest {
     @Test
     public void testSchoolWorkers() throws ImpossibleAllocationException, ImpossibleWorkerDistributionException {
         int populationSize = 10000;
-        int nHouseholds = 2000;
         int nInfections = 10;
 
         Population p = new Population(populationSize);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -23,7 +23,7 @@ public class SchoolTest {
 
     @Test
     public void testSchoolTransProb() {
-        School school = new School();
+        School school = new School(CommunalPlace.Size.MED);
         double expProb = PopulationParameters.get().getpBaseTrans() * 30d / (34000d / 50d);
         double delta = 0.01;
         assertEquals("Unexpected school TransProb", expProb, school.transProb, delta);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -66,7 +66,6 @@ public class ShopTest {
     @Test
     public void testShopWorkers() throws ImpossibleAllocationException, ImpossibleWorkerDistributionException {
         int populationSize = 10000;
-        int nHouseholds = 2000;
         int nInfections = 10;
 
         Population p = new Population(populationSize);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -8,7 +8,6 @@ import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -26,7 +26,7 @@ public class ShopTest {
     public void initialise() throws JsonParseException, IOException {
         ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         //Setup a shop with 2 people
-        shop = new Shop();
+        shop = new Shop(CommunalPlace.Size.MED);
         p1 = new Adult(25, Person.Sex.MALE);
         p2 = new Pensioner(67, Person.Sex.FEMALE);
         Household h1 = new Household(Household.HouseholdType.ADULT, null);

--- a/src/test/java/uk/co/ramp/covid/simulation/population/AdultTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/AdultTest.java
@@ -1,10 +1,8 @@
 package uk.co.ramp.covid.simulation.population;
 
 import com.google.gson.JsonParseException;
-import org.apache.logging.log4j.core.appender.db.jdbc.FactoryMethodConnectionSource;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
-import uk.co.ramp.covid.simulation.util.RNG;
 import java.io.IOException;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
@@ -3,10 +3,8 @@ package uk.co.ramp.covid.simulation.population;
 import com.google.gson.JsonParseException;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.Assert;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.School;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
@@ -1,7 +1,6 @@
 package uk.co.ramp.covid.simulation.population;
 
 import com.google.gson.JsonParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.io.ParameterReader;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
@@ -1,11 +1,9 @@
 package uk.co.ramp.covid.simulation.population;
 
-import org.junit.Assert;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PersonTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PersonTest.java
@@ -26,6 +26,7 @@ public class PersonTest {
         //Test that an infected person's infection status is true
         Person person = new Adult(30, Person.Sex.MALE);
         boolean inf = person.infect();
+        assertTrue("Unexpected value returned by infect()", inf);
         assertTrue("Person unexpectedly not infected", person.getInfectionStatus());
     }
 

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
@@ -4,7 +4,6 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.*;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -16,7 +16,6 @@ public class PopulationTest {
 
     private Population pop;
     private final int populationSize = 10000;
-    private final int nHouseholds = 3000;
 
     @Before
     public void setupParams() throws IOException {
@@ -254,25 +253,23 @@ public class PopulationTest {
 
     @Test
     public void testLockdownOver() {
-        List<DailyStats> stats;
         int nDays = 5;
         int startLockdown = 2;
         int endLockdown = 4;
         double socialDist = 2.0;
         pop.setLockdown(startLockdown, endLockdown, socialDist);
-        stats = pop.simulate(nDays);
+        pop.simulate(nDays);
         assertFalse("Unexpectedly still in lockdown", pop.isLockdown());
     }
 
     @Test
     public void testInLockdown() {
-        List<DailyStats> stats;
         int nDays = 5;
         int start = 3;
         int end = 6;
         double socialDist = 2.0;
         pop.setLockdown(start, end, socialDist);
-        stats = pop.simulate(nDays);
+        pop.simulate(nDays);
         assertTrue("Unexpectedly not in lockdown", pop.isLockdown());
         assertTrue("Restaurants not in lockdown", pop.isrLockdown());
     }
@@ -290,14 +287,13 @@ public class PopulationTest {
 
     @Test
     public void testSchoolExemption() {
-        List<DailyStats> stats;
         int nDays = 5;
         int startLockdown = 1;
         int endLockdown = 5;
         double socialDist = 2.0;
         pop.setLockdown(startLockdown, endLockdown, socialDist);
         pop.setSchoolLockdown(startLockdown, endLockdown - 2, socialDist);
-        stats = pop.simulate(nDays);
+        pop.simulate(nDays);
         for (School s : pop.getPlaces().getSchools()) {
             assertTrue("School should be a key premises", s.isKeyPremises());
         }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/ShiftsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/ShiftsTest.java
@@ -6,11 +6,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.CommunalPlace;
-import uk.co.ramp.covid.simulation.place.OpeningTimes;
-import uk.co.ramp.covid.simulation.place.Restaurant;
 import uk.co.ramp.covid.simulation.place.Shop;
-import uk.co.ramp.covid.simulation.util.RNG;
-import uk.co.ramp.covid.simulation.util.RoundRobinAllocator;
 
 import java.io.IOException;
 


### PR DESCRIPTION
This is a little clean-up to make compiler warning messages more useful.

For example:
- Unused import statements are removed.
- Unused variables are removed.
- `new ArrayList()` is replaced with `new ArrayList<>()`.
- The concept of a place with `UNKNOWN` size is removed, so that case statements which don't mention `UNKNOWN` don't generate warnings.

The changes are broken down into multiple commits, to (hopefully) make the purpose clear.

Four warning messages remain in Eclipse, relating to serialization of Exception classes, but I think it is better to turn this warning off than add explicit serialVersionUID values.  To do this in Eclipse, open the workspace Preferences, then go to `Java Compiler`->`Errors/Warnings`->`Potential programming problems`->`Serializable class without serialVersionUID` and set it to `Ignore`.

I know other people are using other IDEs.  I'd be grateful if you could check if you are getting any warnings after applying these changes.  It would be good to keep them at zero!
