### PR TITLE
Remove invalid install step from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,10 +62,3 @@ sonarqube {
     }
 }
 
-task copyFilesToInstall ( type: Copy){
-    from "contacts.csv", "population.json", "runSettings.json"
-    into "$buildDir/install/ContactTracing/bin/"
-
-}
-
-tasks.getByName("installDist").finalizedBy(copyFilesToInstall)


### PR DESCRIPTION
This appears to be something that was copied over from the Contact-Tracing-Model project, and makes no sense here.