### PR TITLE
Add compiler options to check warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,12 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_8
 }
 
+tasks.withType(JavaCompile).all {
+    options.compilerArgs.add("-Xlint:all")
+    options.compilerArgs.add("-Xlint:-serial")
+    options.compilerArgs.add("-Werror")
+}
+
 run {
     enableAssertions = true
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/covid/Covid.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/covid/Covid.java
@@ -98,10 +98,10 @@ public class Covid {
 
     // For each infection define the duration of the infection periods
     private void setPeriods() {
-        latentPeriod = (double) Math.exp(rng.nextGaussian(Math.log(meanLatentPeriod), 1.0));
+        latentPeriod = Math.exp(rng.nextGaussian(Math.log(meanLatentPeriod), 1.0));
         if(!symptomaticCase) asymptomaticPeriod = Math.exp(rng.nextGaussian(Math.log(meanAsymptomaticPeriod), 1.0));
         else if(symptomaticCase) {
-        	symptomDelay = latentPeriod - (double) rng.nextGaussian(meanSymptomDelay, 1.25); // Basically if symptom delay < 0 then the symproms appear after the infetcious period has started; otherwise before
+        	symptomDelay = latentPeriod - rng.nextGaussian(meanSymptomDelay, 1.25); // Basically if symptom delay < 0 then the symproms appear after the infetcious period has started; otherwise before
         	if(symptomDelay < 1.0) symptomDelay = 1.0; // There could be the odd instance where we have a negative value here 
         
         	infectiousPeriod = Math.exp(rng.nextGaussian(Math.log(meanInfectiousDuration), 1.0));


### PR DESCRIPTION
Add compiler options to enable all warnings, except for the one about missing serialVersionUID in Exception classes, and to turn warnings into errors.  Also, remove redundant casts (from double to double), so that the build is successful.