### PR TITLE
Reseed RNG before running each test

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/RStats.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/RStats.java
@@ -8,7 +8,6 @@ import uk.co.ramp.covid.simulation.population.Population;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /** RStats handles generating/outputting the R naught statistics */
 public class RStats {

--- a/src/test/java/uk/co/ramp/covid/simulation/CovidTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/CovidTest.java
@@ -4,22 +4,21 @@ import org.junit.After;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.covid.Covid;
 import uk.co.ramp.covid.simulation.covid.CovidParameters;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.Household;
 import uk.co.ramp.covid.simulation.population.*;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class CovidTest {
+public class CovidTest extends SimulationTest {
 
     //Test that a pensioner steps through the infection from latent to death
     @Test
     public void testStepInfectionSymptomatic() throws IOException {
         //Use the default parameters with a mortality rate of 100
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         CovidParameters.get().setMortalityRate(100.0);
         CovidParameters.get().setSymptomProbability(100.0);
         CovidParameters.get().setPensionerProgressionPhase2(100.0);
@@ -57,7 +56,6 @@ public class CovidTest {
     //Test that a child steps through the infection from latent to recovered
     @Test
     public void testStepInfectionRecover() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         CStatus cStatus = null;
         Time t = new Time();
         Person child = new Child(6, Person.Sex.FEMALE);
@@ -82,7 +80,6 @@ public class CovidTest {
     //Test that a child steps through the infection from Asymtomatic to recovered
     @Test
     public void testStepInfectionAsymptomatic() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         CovidParameters.get().setSymptomProbability(0.0);
         Person child = new Child(5, Person.Sex.FEMALE);
         Time t = new Time();

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -7,8 +7,8 @@ import org.junit.Test;
 import com.google.gson.JsonParseException;
 
 import uk.co.ramp.covid.simulation.covid.CovidParameters;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import java.io.IOException;
 import java.util.List;
@@ -16,7 +16,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class ModelTest {
+public class ModelTest extends SimulationTest {
 
     int population;
     int nInfections;
@@ -26,7 +26,6 @@ public class ModelTest {
 
     @Before
     public void setupParams() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         population = 10000;
         nInfections = 10;
         nIter = 1;

--- a/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
@@ -1,15 +1,14 @@
 package uk.co.ramp.covid.simulation;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
 import uk.co.ramp.covid.simulation.util.RNG;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -17,7 +16,7 @@ import java.util.List;
 import java.util.Set;
 
 /** Movement tests do not test a particular class, but check basic assumptions around movement throughout a run */
-public class MovementTest {
+public class MovementTest extends SimulationTest {
 
     Population p;
     int populationSize = 10000;
@@ -25,7 +24,6 @@ public class MovementTest {
 
     @Before
     public void initialiseTestModel() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         PopulationParameters.get().setpHouseholdWillIsolate(100.0);
 
         p = PopulationGenerator.genValidPopulation(populationSize);

--- a/src/test/java/uk/co/ramp/covid/simulation/TimeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/TimeTest.java
@@ -33,10 +33,13 @@ public class TimeTest {
     @Test
     public void weekRolleroverWorks() {
         Time t = new Time(168);
-        Time t2 = t.advance();
         assertEquals(0, t.getDay());
         assertEquals(7, t.getAbsDay());
         assertEquals(0, t.getHour());
+        Time t2 = t.advance();
+        assertEquals(0, t2.getDay());
+        assertEquals(7, t2.getAbsDay());
+        assertEquals(1, t2.getHour());
     }
 
 

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
@@ -1,8 +1,5 @@
 package uk.co.ramp.covid.simulation.place;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
@@ -10,22 +7,16 @@ import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.Model;
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.*;
 
-public class ConstructionSiteTest {
-
-    @Before
-    public void setupParams() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-    }
+public class ConstructionSiteTest extends SimulationTest {
 
     @Test
     public void testConstructionSiteTransProb() throws JsonParseException {

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -1,28 +1,20 @@
 package uk.co.ramp.covid.simulation.place;
 
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.List;
 
-public class HospitalTest {
-
-    @Before
-    public void setupParams() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-    }
+public class HospitalTest extends SimulationTest {
 
     @Test
     public void testHospitalTransProb() throws JsonParseException {

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -6,17 +6,17 @@ import org.junit.Test;
 import com.google.gson.JsonParseException;
 
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.Adult;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.PopulationParameters;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
-public class HouseholdTest {
+public class HouseholdTest extends SimulationTest {
 
     Household household;
 
@@ -27,7 +27,6 @@ public class HouseholdTest {
 
     @Before
     public void initialise() throws JsonParseException, IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         household = new Household(Household.HouseholdType.ADULT, null);
         Person p1 = new Adult(30, Person.Sex.MALE);
         Person p2 = new Adult(32, Person.Sex.FEMALE);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
@@ -1,28 +1,20 @@
 package uk.co.ramp.covid.simulation.place;
 
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.List;
 
-public class NurseryTest {
-
-    @Before
-    public void setupParams() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-    }
+public class NurseryTest extends SimulationTest {
 
     @Test
     public void testNurseryTransProb() throws JsonParseException {

--- a/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
@@ -1,28 +1,20 @@
 package uk.co.ramp.covid.simulation.place;
 
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.List;
 
-public class OfficeTest {
-
-    @Before
-    public void setupParams() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-    }
+public class OfficeTest extends SimulationTest {
 
     @Test
     public void testOfficeTransProb() throws JsonParseException {

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -1,15 +1,14 @@
 package uk.co.ramp.covid.simulation.place;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -18,7 +17,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class RestaurantTest {
+public class RestaurantTest extends SimulationTest {
 
     Restaurant restaurant;
     Person p1;
@@ -26,8 +25,6 @@ public class RestaurantTest {
 
     @Before
     public void initialise() throws JsonParseException, IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-
         //Setup a restaurant with 2 people
         restaurant = new Restaurant(CommunalPlace.Size.MED);
         p1 = new Adult(30, Person.Sex.MALE);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -1,27 +1,18 @@
 package uk.co.ramp.covid.simulation.place;
 
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
-import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class SchoolTest {
-
-
-    @Before
-    public void setupParams() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-    }
+public class SchoolTest extends SimulationTest {
 
     @Test
     public void testSchoolTransProb() {

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -1,15 +1,14 @@
 package uk.co.ramp.covid.simulation.place;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.Time;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -18,7 +17,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class ShopTest {
+public class ShopTest extends SimulationTest {
 
     Shop shop;
     Person p1;
@@ -26,7 +25,6 @@ public class ShopTest {
 
     @Before
     public void initialise() throws JsonParseException, IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         //Setup a shop with 2 people
         shop = new Shop(CommunalPlace.Size.MED);
         p1 = new Adult(25, Person.Sex.MALE);

--- a/src/test/java/uk/co/ramp/covid/simulation/population/AdultTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/AdultTest.java
@@ -2,16 +2,16 @@ package uk.co.ramp.covid.simulation.population;
 
 import com.google.gson.JsonParseException;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
+
 import java.io.IOException;
 import static org.junit.Assert.assertTrue;
 
-public class AdultTest {
+public class AdultTest extends SimulationTest {
 
     @Test
     public void testSetProfession() throws JsonParseException, IOException {
         //Test that a profession is set for an adult
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         Adult adult = new Adult(30, Person.Sex.FEMALE);
         adult.setProfession();
         boolean professionSet = false;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
@@ -1,20 +1,18 @@
 package uk.co.ramp.covid.simulation.population;
 
 import com.google.gson.JsonParseException;
-import org.junit.Ignore;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.School;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import java.io.IOException;
 import static org.junit.Assert.assertTrue;
 
-public class ChildTest {
+public class ChildTest extends SimulationTest {
 
     @Test
     public void testChildAtSchool() throws JsonParseException, IOException, ImpossibleAllocationException, ImpossibleWorkerDistributionException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         Population p = PopulationGenerator.genValidPopulation(5000);
         Child child = new Child(10, Person.Sex.MALE);
         child.allocateCommunalPlace(p.getPlaces());

--- a/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
@@ -3,19 +3,17 @@ package uk.co.ramp.covid.simulation.population;
 import com.google.gson.JsonParseException;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
-import uk.co.ramp.covid.simulation.util.RNG;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
+
 import java.io.IOException;
 import java.util.List;
 import static org.junit.Assert.assertEquals;
 
-public class InfantTest {
+public class InfantTest extends SimulationTest {
 
     @Test
     public void testInfant() throws JsonParseException, IOException {
-        RNG.seed(0); // This test is sensitive to random numbers
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         int nNursery = 0;
         //Test 50% of infants go to nursery
         for (int i = 0; i < 1000; i++) {
@@ -28,7 +26,6 @@ public class InfantTest {
     @Test
     public void testInfantReports() throws IOException, ImpossibleAllocationException, ImpossibleWorkerDistributionException {
         //Test Infant methods reportInfection() and reportDeath()
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         Population p = PopulationGenerator.genValidPopulation(500);
         Infant infant = new Infant(3, Person.Sex.FEMALE);
 

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
@@ -2,20 +2,19 @@ package uk.co.ramp.covid.simulation.population;
 
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-public class PensionerTest {
+public class PensionerTest extends SimulationTest {
 
     @Test
     public void testPensionerReports() throws IOException, ImpossibleAllocationException, ImpossibleWorkerDistributionException {
         //Test Pensioner methods reportInfection() and reportDeath()
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         Population p = PopulationGenerator.genValidPopulation(500);
         Pensioner pensioner = new Pensioner(70, Person.Sex.MALE);
 

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PersonTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PersonTest.java
@@ -1,19 +1,12 @@
 package uk.co.ramp.covid.simulation.population;
 
-import com.google.gson.JsonParseException;
-import org.junit.Before;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
-import java.io.IOException;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
+
 import static org.junit.Assert.*;
 
-public class PersonTest {
-
-    @Before
-    public void initialise() throws JsonParseException, IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-    }
+public class PersonTest extends SimulationTest {
 
     @Test
     public void testInfect() {

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
@@ -1,24 +1,15 @@
 package uk.co.ramp.covid.simulation.population;
 
-import org.junit.Before;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.*;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.*;
 
-public class PlacesTest {
-
-    @Before
-    public void setupParams() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-        // NOTE: This test is not guaranteed to pass with a different seed due to randomness
-    }
-
+public class PlacesTest extends SimulationTest {
 
     @Test
     public void getRandomOffice() {

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationDistributionTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationDistributionTest.java
@@ -1,16 +1,15 @@
 package uk.co.ramp.covid.simulation.population;
 
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.*;
 
-public class PopulationDistributionTest {
+public class PopulationDistributionTest extends SimulationTest {
 
     @Test(expected = InvalidParametersException.class)
     public void readFromMapNonBreakableKey() {
@@ -62,8 +61,7 @@ public class PopulationDistributionTest {
     }
 
     @Test
-    public void seeAllAgesInALargeSample() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
+    public void seeAllAgesInALargeSample() {
         PopulationDistribution dist = new PopulationDistribution();
         dist.readFromMap(PopulationParameters.get().getPopulation());
 

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -4,7 +4,6 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.RStats;
-import uk.co.ramp.covid.simulation.covid.CovidParameters;
 import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -4,23 +4,22 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.RStats;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.*;
 
-public class PopulationTest {
+public class PopulationTest extends SimulationTest {
 
     private Population pop;
     private final int populationSize = 10000;
 
     @Before
     public void setupParams() throws IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
         pop = PopulationGenerator.genValidPopulation(populationSize);
     }
 

--- a/src/test/java/uk/co/ramp/covid/simulation/population/ShiftsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/ShiftsTest.java
@@ -2,27 +2,23 @@ package uk.co.ramp.covid.simulation.population;
 
 
 import com.google.gson.JsonParseException;
-import org.junit.Ignore;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.io.ParameterReader;
 import uk.co.ramp.covid.simulation.place.CommunalPlace;
 import uk.co.ramp.covid.simulation.place.Shop;
+import uk.co.ramp.covid.simulation.util.SimulationTest;
 
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
-public class ShiftsTest {
+public class ShiftsTest extends SimulationTest {
 
     @Test
     public void testGetShift() throws JsonParseException, IOException {
-        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
-
        Shop shop = new Shop(CommunalPlace.Size.LARGE);
        int end = shop.getShifts().getShift(1).getEnd();
        assertEquals(15, end);
        end = shop.getShifts().getShift(1).getEnd();
        assertEquals(22, end);
-
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/util/SimulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/util/SimulationTest.java
@@ -1,0 +1,24 @@
+package uk.co.ramp.covid.simulation.util;
+
+import java.io.IOException;
+
+import org.junit.Before;
+
+import com.google.gson.JsonParseException;
+
+import uk.co.ramp.covid.simulation.io.ParameterReader;
+
+/**
+ * SimulationTest is a base class for setting up tests
+ */
+public class SimulationTest {
+    @Before
+    public void readDefaultParams() throws JsonParseException, IOException {
+        ParameterReader.readParametersFromFile("src/test/resources/default_params.json");
+    }
+
+    @Before
+    public void seedRNG() {
+        RNG.seed(0);
+    }
+}


### PR DESCRIPTION
I'm looking at making tests more robust to different random numbers, and this is some preparatory work.

I've added a new base class for tests (SimulationTest.java), which loads the default parameters and reseeds the RNG before tests run.  (This is not done for the tests where it doesn't make sense, such as tests which don't use the RNG or default parameters.)  Previously, the results of tests were different depending upon where they were run - although the RNG was being seeded with a fixed value, it was not being reseeded between every test.