### PR TITLE
Add option to seed the RNG automatically

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -95,6 +95,10 @@ public class Model {
         return this;
     }
 
+    public Integer getRNGSeed() {
+        return rngSeed;
+    }
+
     public Model setSchoolLockdown(int start, int end, double socialDistance) {
         this.schoolLockDown = new Lockdown(start, end, socialDistance);
         return this;
@@ -237,4 +241,10 @@ public class Model {
         return m;
     }
 
+    public void optionallyGenerateRNGSeed() {
+        if (rngSeed == null) {
+            rngSeed = RNG.generateRandomSeed();
+            LOGGER.warn("Generated RNG seed: " + rngSeed);
+        }
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/RunModel.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/RunModel.java
@@ -40,6 +40,7 @@ public class RunModel {
             }
 
             Model m  = Model.readModelFromFile(modelParamsFile);
+            m.optionallyGenerateRNGSeed();
 
             if (!m.isValid()) {
                 LOGGER.error("Could not read model parameters");

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -12,7 +12,6 @@ public abstract class Household extends Place {
 
     private final List<Household> neighbours;
     private final Places places;
-    private int householdSize = 0;
     
     private boolean willIsolate = false;
     private boolean lockCompliant = false;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/AdultPensioner.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/AdultPensioner.java
@@ -2,7 +2,6 @@ package uk.co.ramp.covid.simulation.place.householdtypes;
 
 import uk.co.ramp.covid.simulation.place.Household;
 import uk.co.ramp.covid.simulation.population.Places;
-import uk.co.ramp.covid.simulation.util.RNG;
 
 /** AdultPensioner: one adult aged 16-64 and one of pensionable age and no children */
 

--- a/src/main/java/uk/co/ramp/covid/simulation/util/RNG.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/RNG.java
@@ -22,4 +22,9 @@ public class RNG {
     public static void seed(int seed) {
         get().reSeed(seed);
     }
+    
+    public static int generateRandomSeed() {
+        // The default generator is seeded with System.currentTimeMillis() + System.identityHashCode(this)).
+        return (new RandomDataGenerator()).nextInt(0, Integer.MAX_VALUE);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/util/RNG.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/RNG.java
@@ -10,17 +10,14 @@ public class RNG {
 
     public static RandomDataGenerator get() {
         if (rng == null) {
-            rng = new RandomDataGenerator();
-
-            // Use a fixed seed for tests
-            // - seed() will always be called to override this in non-test runs  
-            rng.reSeed(0);
+            throw new NullPointerException("The RNG must be seeded before use.");
         }
         return rng;
     }
 
     public static void seed(int seed) {
-        get().reSeed(seed);
+        rng = new RandomDataGenerator();
+        rng.reSeed(seed);
     }
     
     public static int generateRandomSeed() {

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ModelTest extends SimulationTest {
@@ -129,6 +131,21 @@ public class ModelTest extends SimulationTest {
         m.setNoOutput();
         assertTrue(m.isValid());
         m.run(0);
+    }
+    
+    @Test
+    public void testRNGSeedGeneration() throws JsonParseException, IOException {
+        Model m  = Model.readModelFromFile("src/test/resources/test_model_params.json");
+        m.optionallyGenerateRNGSeed();
+        assertEquals(42, (int)m.getRNGSeed());
+
+        Model m2  = Model.readModelFromFile("src/test/resources/test_model_params_with_no_seed.json");
+        assertNull(m2.getRNGSeed());
+        assertFalse(m2.isValid());
+
+        // This also should write the new seed to the log
+        m2.optionallyGenerateRNGSeed();
+        assertTrue(m2.isValid());
     }
 
     @Ignore("Failing Test")

--- a/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/MovementTest.java
@@ -381,7 +381,6 @@ public class MovementTest extends SimulationTest {
     @Test
     public void negativeTestsExitQuarantine() {
         Time t = new Time(24);
-        DailyStats s = new DailyStats(t);
 
         Household iso = null;
         for (Household h : p.getHouseholds()) {
@@ -415,7 +414,6 @@ public class MovementTest extends SimulationTest {
     @Test
     public void positiveTestsStayInQuarantine() {
         Time t = new Time(24);
-        DailyStats s = new DailyStats(t);
 
         Household iso = null;
         for (Household h : p.getHouseholds()) {

--- a/src/test/java/uk/co/ramp/covid/simulation/RStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/RStatsTest.java
@@ -25,7 +25,7 @@ public class RStatsTest extends SimulationTest {
         RStats rs = new RStats(pop);
 
         for (int i = 0; i < 20; i++) {
-            assertNull(rs.getMeanR(i));
+            assertNull(rs.getSecInfections(i));
             assertNull(rs.getMeanGenerationTime(i));
         }
     }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/AdultTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/AdultTest.java
@@ -30,6 +30,6 @@ public class AdultTest extends SimulationTest {
 
     @Test (expected = InvalidAgeException.class)
     public void testInvalidAgeException() {
-        Adult adult = new Adult(66, FEMALE);
+        new Adult(66, FEMALE);
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
@@ -21,6 +21,6 @@ public class ChildTest extends SimulationTest {
 
     @Test (expected = InvalidAgeException.class)
     public void testInvalidAgeException() {
-        Child child = new Child(1, FEMALE);
+        new Child(1, FEMALE);
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
@@ -42,6 +42,6 @@ public class InfantTest extends SimulationTest {
 
     @Test (expected = InvalidAgeException.class)
     public void testInvalidAgeException() {
-        Infant infant = new Infant(5, FEMALE);
+        new Infant(5, FEMALE);
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
@@ -31,7 +31,7 @@ public class PensionerTest extends SimulationTest {
 
     @Test (expected = InvalidAgeException.class)
     public void testInvalidAgeException() {
-        Pensioner pensioner = new Pensioner(5, FEMALE);
+        new Pensioner(5, FEMALE);
     }
 
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -3,7 +3,6 @@ package uk.co.ramp.covid.simulation.population;
 import org.junit.Before;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.DailyStats;
-import uk.co.ramp.covid.simulation.RStats;
 import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.place.householdtypes.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;

--- a/src/test/resources/test_model_params_with_no_seed.json
+++ b/src/test/resources/test_model_params_with_no_seed.json
@@ -1,0 +1,7 @@
+{
+    "populationSize":10000,
+    "nInfections":10,
+    "nDays":10,
+    "nIters":1,
+    "outputFile":"./example.csv"
+}


### PR DESCRIPTION
There are actually 4 independent changes here, in 4 commits, so I suggest looking at the changes for the individual commits separately.  The main change is adding the option to seed the RNG automatically when the "rngSeed" parameter is not included in the parameters file.

I have made quite a choices in the implementation which I was a bit unsure about, so will be very happy to receive comments.