### PR TITLE
Improve general performance

### DIFF
--- a/parameters/example_model_params_lockdown.json
+++ b/parameters/example_model_params_lockdown.json
@@ -6,7 +6,7 @@
     "nDays":365,
     "nIters":1,
     "rngSeed":42,
-    "outputFile":"./example-lockdown.csv",
+    "outputDirectory":".",
     "lockDown":{
         "start":20,
         "end":50,

--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -162,6 +162,8 @@
             "pAttendsNursery":0.5
         },
         "householdProperties":{
+            "neighbourOpeningTime":9,
+            "neighbourClosingTime":20,
             "pVisitorsLeaveHousehold":0.5,
             "pHouseholdVisitsNeighbourDaily":0.144,
             "expectedNeighbours":3,

--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -159,7 +159,7 @@
         },
         "householdProperties":{
             "pVisitorsLeaveHousehold":0.5,
-            "pHouseholdVisitsNeighbour":0.006,
+            "pHouseholdVisitsNeighbourDaily":0.144,
             "expectedNeighbours":3,
             "pGoShopping":0.01786,
             "pGoRestaurant": 0.01190,

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/HouseholdProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/HouseholdProperties.java
@@ -12,4 +12,7 @@ public class HouseholdProperties {
     public Integer householdIsolationPeriod = null;
     public Probability pWillIsolate = null;
     public Probability pLockCompliance = null;
+    
+    public Integer neighbourOpeningTime = null;
+    public Integer neighbourClosingTime = null;
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/HouseholdProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/HouseholdProperties.java
@@ -4,7 +4,7 @@ import uk.co.ramp.covid.simulation.util.Probability;
 
 public class HouseholdProperties {
     public Probability pVisitorsLeaveHousehold = null;
-    public Probability pHouseholdVisitsNeighbour = null;
+    public Probability pHouseholdVisitsNeighbourDaily = null;
     public Integer expectedNeighbours = null;
 
     public Probability pGoShopping = null;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -90,7 +90,12 @@ public abstract class Household extends Place {
     public int sendNeighboursHome(Time t) {
         ArrayList<Person> left = new ArrayList<>();
 
-        for (Person p : getVisitors()) {
+        for (Person p : people) {
+
+            if (!isVisitor(p)) {
+                continue;
+            }
+
             // People may have already left if their family has
             if (left.contains(p)) {
                 continue;
@@ -222,6 +227,10 @@ public abstract class Household extends Place {
 	                        left.add(p);
 	                    }
 	                }
+
+	                // One neighbour visit max per day
+	                visitsNeighbourToday = false;
+
 	                break;
 	            }
 	        }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -205,8 +205,9 @@ public abstract class Household extends Place {
     }
 
     private void moveNeighbour(Time t, boolean lockdown) {
-        // We only visit neighbours between 9 - 20
-        if (!visitsNeighbourToday || t.getHour() < 8 || t.getHour() >= 19) {
+       if (!visitsNeighbourToday
+                || t.getHour() + 1 < PopulationParameters.get().householdProperties.neighbourOpeningTime
+                || t.getHour() + 1 >= PopulationParameters.get().householdProperties.neighbourClosingTime) {
             return;
         }
 
@@ -218,8 +219,10 @@ public abstract class Household extends Place {
 	            }
 
 	            // Since we determine if we should try to visit a neighbour a the star of the day, we have
-                // equal oppertunity of visiting a neighbour each hour they are open
-                if (new Probability(1.0 / (18 - 8)).sample()) {
+                // equal opportunity of visiting a neighbour each hour they are open
+                int openT = PopulationParameters.get().householdProperties.neighbourOpeningTime;
+                int closeT = PopulationParameters.get().householdProperties.neighbourClosingTime;
+                if (new Probability(1.0 / (closeT - openT)).sample()) {
 	                // We visit neighbours as a family
 	                for (Person p : people) {
 	                    if (isInhabitant(p) && !p.getQuarantine()) {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -201,7 +201,7 @@ public abstract class Household extends Place {
 
     private void moveNeighbour(Time t, boolean lockdown) {
         // We only visit neighbours between 9 - 20
-        if (!visitsNeighbourToday || t.getAbsTime() < 8 || t.getAbsTime() >= 19) {
+        if (!visitsNeighbourToday || t.getHour() < 8 || t.getHour() >= 19) {
             return;
         }
 
@@ -212,7 +212,9 @@ public abstract class Household extends Place {
 	                continue;
 	            }
 
-                if (PopulationParameters.get().householdProperties.pHouseholdVisitsNeighbour.sample()) {
+	            // Since we determine if we should try to visit a neighbour a the star of the day, we have
+                // equal oppertunity of visiting a neighbour each hour they are open
+                if (new Probability(1.0 / (18 - 8)).sample()) {
 	                // We visit neighbours as a family
 	                for (Person p : people) {
 	                    if (isInhabitant(p) && !p.getQuarantine()) {
@@ -309,15 +311,16 @@ public abstract class Household extends Place {
             isolationTimer--;
         }
 
-        visitsNeighbourToday = false;
-
-        // Determine if we will visit a neighbour tomorrow
-        double hourlyP = PopulationParameters.get().householdProperties.pHouseholdVisitsNeighbour.asDouble();
-        Probability visitNeighbourDay = new Probability(hourlyP * 24);
-        if (visitNeighbourDay.sample()) {
+        determineDailyNeighbourVisit();
+    }
+    
+    public void determineDailyNeighbourVisit() {
+        // Determine if we will attempt to visit a neighbour tomorrow
+        if (PopulationParameters.get().householdProperties.pHouseholdVisitsNeighbourDaily.sample()) {
             visitsNeighbourToday = true;
+        } else {
+            visitsNeighbourToday = false;
         }
-
     }
 
     // Household Type management

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -89,10 +89,15 @@ public abstract class Place {
     
     /** Do a timestep by switching to the new set of people */
     public void stepPeople() {
+
         // Anyone who didn't move should remain.
         nextPeople.addAll(people);
+
+        // Switch the movement buffers
+        List<Person> tmp = people;
         people = nextPeople;
-        nextPeople = new ArrayList<>();
+        nextPeople = tmp;
+        nextPeople.clear();
     }
 
     public List<Person> sendFamilyHome(Person p, CommunalPlace place, Time t) {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -192,8 +192,14 @@ public abstract class Person {
 
 
     public boolean worksNextHour(CommunalPlace communalPlace, Time t, boolean lockdown) {
-        if (primaryPlace == null || shifts == null) {
+        if (primaryPlace == null || shifts == null || primaryPlace != communalPlace) {
             return false;
+        }
+
+        if (lockdown) {
+            if (!communalPlace.isKeyPremises()) {
+                return false;
+            }
         }
 
         // Handle day crossovers
@@ -212,19 +218,8 @@ public abstract class Person {
             end += 24;
         }
 
-        boolean shouldWork =
-                primaryPlace == communalPlace
-                && nextHour >= start
-                && nextHour < end;
+        boolean shouldWork = nextHour >= start && nextHour < end;
 
-        if (lockdown) {
-            if (communalPlace.isKeyPremises()) {
-                return shouldWork;
-            } else {
-                return false;
-            }
-        }
-        
         return shouldWork;
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -293,6 +293,9 @@ public class Population {
         List<DailyStats> stats = new ArrayList<>(nDays);
         Time t = new Time();
         boolean rprinted = false;
+
+        households.forEach(h -> h.determineDailyNeighbourVisit());
+
         for (int i = 0; i < nDays; i++) {
             DailyStats dStats = new DailyStats(t);
             implementLockdown(t);

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -268,22 +268,24 @@ public class Population {
     }
     
     public void timeStep(Time t, DailyStats dStats) {
-        households.forEach(h -> h.doInfect(t, dStats));
-        places.getAllPlaces().forEach(p -> p.doInfect(t, dStats));
-
-        // There is a potential to introduce parallelism here if required by using parallelStream (see below).
-        // Note we currently cannot parallelise movement as the ArrayLists for capturing moves are not thread safe
-        // households.parallelStream().forEach(h -> h.doInfect(dStats));
-        // places.getAllPlaces().parallelStream().forEach(p -> p.doInfect(dStats));
-
-        households.forEach(h -> h.doTesting(t));
-
         // Movement places people in "next" buffers (to avoid people moving twice in an hour)
-        households.forEach(h -> h.doMovement(t, lockdown));
-        places.getAllPlaces().forEach(p -> p.doMovement(t, lockdown));
+        for (Household h : households) {
+            h.doTesting(t);
+            h.doInfect(t, dStats);
+            h.doMovement(t, lockdown);
+        }
+        for (Place p : places.getAllPlaces()) {
+            p.doInfect(t, dStats);
+            p.doMovement(t, lockdown);
+        };
 
-        households.forEach(h -> h.stepPeople());
-        places.getAllPlaces().forEach(p -> p.stepPeople());
+        for (Household h : households) {
+            h.stepPeople();
+        }
+
+        for (Place p : places.getAllPlaces()) {
+            p.stepPeople();
+        };
     }
 
     // Step through nDays in 1 hour time steps

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -226,7 +226,7 @@ public class ModelTest extends SimulationTest {
         //Run the model
         Model m1 = new Model()
                 .setPopulationSize(population)
-                .setnInitialInfections(nInfections * 10)
+                .setnInitialInfections(nInfections * 30)
                 .setExternalInfectionDays(0)
                 .setIters(nIter)
                 .setnDays(nDays)

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -180,6 +180,8 @@ public class MovementTest extends SimulationTest {
     public void somePeopleVisitNeighbours() {
         Set<Person> visiting = new HashSet<>();
         Time t = new Time(24);
+        PopulationParameters.get().householdProperties.pHouseholdVisitsNeighbourDaily = new Probability(0.5);
+        p.getHouseholds().forEach(h -> h.determineDailyNeighbourVisit());
         DailyStats s = new DailyStats(t);
         for (int i = 0; i < 24; i++) {
             p.timeStep(t, s);

--- a/src/test/java/uk/co/ramp/covid/simulation/io/ParameterReaderTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/io/ParameterReaderTest.java
@@ -68,7 +68,7 @@ public class ParameterReaderTest {
 
         assertEqualsP(0.8, PopulationParameters.get().infantProperties.pAttendsNursery, EPSILON);
 
-        assertEqualsP(0.05, PopulationParameters.get().householdProperties.pHouseholdVisitsNeighbour, EPSILON);
+        assertEqualsP(0.144, PopulationParameters.get().householdProperties.pHouseholdVisitsNeighbourDaily, EPSILON);
         assertEquals(2, (int) PopulationParameters.get().householdProperties.expectedNeighbours);
 
         assertEqualsP(0.9, PopulationParameters.get().personProperties.pTransmission, EPSILON);

--- a/src/test/resources/default_params.json
+++ b/src/test/resources/default_params.json
@@ -162,6 +162,8 @@
             "pAttendsNursery":0.5
         },
         "householdProperties":{
+            "neighbourOpeningTime":9,
+            "neighbourClosingTime":20,
             "pVisitorsLeaveHousehold":0.5,
             "pHouseholdVisitsNeighbourDaily":0.144,
             "expectedNeighbours":3,

--- a/src/test/resources/default_params.json
+++ b/src/test/resources/default_params.json
@@ -159,7 +159,7 @@
         },
         "householdProperties":{
             "pVisitorsLeaveHousehold":0.5,
-            "pHouseholdVisitsNeighbour":0.006,
+            "pHouseholdVisitsNeighbourDaily":0.144,
             "expectedNeighbours":3,
             "pGoShopping":0.01786,
             "pGoRestaurant": 0.01190,

--- a/src/test/resources/test_params.json
+++ b/src/test/resources/test_params.json
@@ -161,6 +161,8 @@
             "pAttendsNursery":0.8
         },
         "householdProperties":{
+            "neighbourOpeningTime":9,
+            "neighbourClosingTime":20,
             "pHouseholdVisitsNeighbourDaily":0.144,
             "pVisitorsLeaveHousehold":0.8,
             "expectedNeighbours":2,

--- a/src/test/resources/test_params.json
+++ b/src/test/resources/test_params.json
@@ -157,7 +157,7 @@
             "pAttendsNursery":0.8
         },
         "householdProperties":{
-            "pHouseholdVisitsNeighbour":0.05,
+            "pHouseholdVisitsNeighbourDaily":0.144,
             "pVisitorsLeaveHousehold":0.8,
             "expectedNeighbours":2,
             "pGoShopping":0.01786,


### PR DESCRIPTION
This PR improves the general performance from around 1.7s per day to 0.6s per day.

Biggest changes includes determining if we (try to) visit a neighbour at a daily level, and various optimisations to reduce the number of iterations over the households. We also avoid extra allocations when possible.

@paulbessell Can you focus your review in particular on the probabilities for neighbour movement to make sure I've not totally messed these up!