### PR TITLE
Add NetworkGenerator

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -65,6 +65,7 @@ public class Model {
     private String outputDirectory = null;
     private Lockdown lockDown = null;
     private Lockdown schoolLockDown = null;
+    private String networkOutputDir = null;
 
     public Model() {}
 
@@ -120,6 +121,11 @@ public class Model {
 
     public Model setOutputDirectory(String fname) {
         this.outputDirectory = fname;
+        return this;
+    }
+
+    public Model setNetworkOutputDir(String path) {
+        this.networkOutputDir = path;
         return this;
     }
 
@@ -198,6 +204,14 @@ public class Model {
                 break;
             }
 
+            if (networkOutputDir != null) {
+                try {
+                    NetworkGenerator.startNetworkGeneration(p.getAllPeople(), networkOutputDir);
+                } catch (IOException e) {
+                    LOGGER.error("Error starting network generation", e);
+                    break;
+                }
+            }
 
             p.setExternalInfectionDays(externalInfectionDays);
             p.seedVirus(nInitialInfections);

--- a/src/main/java/uk/co/ramp/covid/simulation/NetworkGenerator.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/NetworkGenerator.java
@@ -1,0 +1,51 @@
+package uk.co.ramp.covid.simulation;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+
+import uk.co.ramp.covid.simulation.place.Place;
+import uk.co.ramp.covid.simulation.population.Person;
+
+public class NetworkGenerator {
+    private static CSVPrinter contactsPrinter = null;
+    
+    private static void writePeople(ArrayList<Person> allPeople, String outputDir) throws IOException {
+        String[] headers = {"id", "age"};
+        File outputFile = new File(outputDir, "people.csv");
+
+        CSVPrinter csv = new CSVPrinter(new FileWriter(outputFile), CSVFormat.DEFAULT.withHeader(headers));
+
+        for (Person p : allPeople) {
+            csv.printRecord(p.getID(), p.getAge());
+        }
+        csv.close();
+    }
+    
+    private static void openContactsPrinter(String outputDir) throws IOException {
+        String[] headers = {""};
+        File outputFile = new File(outputDir, "contacts.csv");
+        contactsPrinter = new CSVPrinter(new FileWriter(outputFile), CSVFormat.DEFAULT.withHeader(headers));
+    }
+
+    public static void startNetworkGeneration(ArrayList<Person> allPeople, String outputDir) throws IOException {
+        writePeople(allPeople, outputDir);
+        openContactsPrinter(outputDir);
+    }
+    
+    public static boolean generating() {
+        return contactsPrinter != null;
+    }
+    
+    public static void writeContact(Time t, Person a, Person b, Place place, double weight) {
+        try {
+            contactsPrinter.printRecord(t.getAbsTime(), a.getID(), b.getID(), place.getClass().getSimpleName(), weight);
+        } catch (IOException e) {
+            throw new NetworkGeneratorException("Error writing contacts", e);
+        }
+    }
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/NetworkGeneratorException.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/NetworkGeneratorException.java
@@ -1,0 +1,8 @@
+package uk.co.ramp.covid.simulation;
+
+public class NetworkGeneratorException extends RuntimeException {
+
+    public NetworkGeneratorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/CovidParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/CovidParameters.java
@@ -1,9 +1,6 @@
 package uk.co.ramp.covid.simulation.parameters;
 
-import uk.co.ramp.covid.simulation.covid.Covid;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;
-
-import java.util.HashMap;
 
 /**
  * CovidParameters is a singleton class for reading and storing the covid disease parameters

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -1,6 +1,7 @@
 package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.DailyStats;
+import uk.co.ramp.covid.simulation.NetworkGenerator;
 import uk.co.ramp.covid.simulation.Time;
 import uk.co.ramp.covid.simulation.population.CStatus;
 import uk.co.ramp.covid.simulation.population.Person;
@@ -55,8 +56,23 @@ public abstract class Place {
         return transConstant * transAdjustment / people.size();
     }
     
+    private void writeContact(Time t) {
+        for (Person a : people) {
+            for (Person b : people) {
+                if (a != b) {
+                    NetworkGenerator.writeContact(t, a, b, this, this.getTransConstant());
+                }
+            }
+        }
+    }
+
     /** Handles infections between all people in this place */
     public void doInfect(Time t, DailyStats stats) {
+        if (NetworkGenerator.generating()) {
+            writeContact(t);
+            return; // don't do infections
+        }
+
         List<Person> deaths = new ArrayList<>();
         for (Person cPers : people) {
             if (cPers.getInfectionStatus() && !cPers.isRecovered()) {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -39,6 +39,9 @@ public abstract class Person {
     private Optional<Boolean> testOutcome = Optional.empty();
     protected final RandomDataGenerator rng;
     
+    private static int nPeople = 0;
+    private final int idForNetworkGenerator;
+
     public abstract void reportInfection(DailyStats s);
     public abstract void reportDeath (DailyStats s);
     public abstract void allocateCommunalPlace(Places p);
@@ -51,6 +54,7 @@ public abstract class Person {
         this.transmissionProb = PopulationParameters.get().personProperties.pTransmission.asDouble();
         this.quarantineProb = PopulationParameters.get().personProperties.pQuarantinesIfSymptomatic;
         this.quarantineVal = rng.nextUniform(0, 1);
+        this.idForNetworkGenerator = nPeople++;
     }
 
     public boolean isRecovered() {
@@ -266,6 +270,10 @@ public abstract class Person {
 
     public Optional<Boolean> getTestOutcome() {
         return testOutcome;
+    }
+
+    public int getID() {
+        return idForNetworkGenerator;
     }
 
     public void seedInfectionChallenge(Time t, DailyStats s) {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.RStats;
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationDistribution;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.*;

--- a/src/main/java/uk/co/ramp/covid/simulation/util/ProbabilityDistribution.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/ProbabilityDistribution.java
@@ -1,7 +1,5 @@
 package uk.co.ramp.covid.simulation.util;
 
-import org.apache.commons.math3.random.RandomDataGenerator;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/test/java/uk/co/ramp/covid/simulation/parameters/CovidParametersTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/parameters/CovidParametersTest.java
@@ -1,8 +1,6 @@
 package uk.co.ramp.covid.simulation.parameters;
 
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.parameters.CovidParameters;
-import uk.co.ramp.covid.simulation.parameters.ParameterIO;
 
 import java.io.IOException;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/parameters/ExampleParametersTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/parameters/ExampleParametersTest.java
@@ -5,9 +5,6 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import uk.co.ramp.covid.simulation.Model;
-import uk.co.ramp.covid.simulation.parameters.CovidParameters;
-import uk.co.ramp.covid.simulation.parameters.ParameterIO;
-import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 
 public class ExampleParametersTest {
 

--- a/src/test/java/uk/co/ramp/covid/simulation/parameters/ParameterIOTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/parameters/ParameterIOTest.java
@@ -2,9 +2,6 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import org.junit.After;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.parameters.CovidParameters;
-import uk.co.ramp.covid.simulation.parameters.ParameterIO;
-import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.util.Probability;
 
 import java.io.IOException;

--- a/src/test/java/uk/co/ramp/covid/simulation/parameters/PopulationParametersTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/parameters/PopulationParametersTest.java
@@ -2,8 +2,6 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import org.junit.After;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.parameters.ParameterIO;
-import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;
 
 import java.io.IOException;


### PR DESCRIPTION
This demonstrates an idea of how we might use Covid_Simulation_Model to generate input files for the Contact-Tracing-Model.  This would potentially enable some cross-validation of the disease models, and also enable us to answer some policy questions that we couldn't answer with either model alone.