### PR TITLE
Ensure new directory for run outputs

### DIFF
--- a/parameters/example_model_params.json
+++ b/parameters/example_model_params.json
@@ -5,5 +5,5 @@
     "nDays":365,
     "nIters":1,
     "rngSeed":42,
-    "outputFile":"./example.csv"
+    "outputDirectory": "."
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -7,8 +7,7 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.co.ramp.covid.simulation.parameters.CovidParameters;
-import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
+import uk.co.ramp.covid.simulation.parameters.ParameterWriter;
 import uk.co.ramp.covid.simulation.population.ImpossibleAllocationException;
 import uk.co.ramp.covid.simulation.population.ImpossibleWorkerDistributionException;
 import uk.co.ramp.covid.simulation.population.Population;
@@ -18,10 +17,6 @@ import uk.co.ramp.covid.simulation.util.RNG;
 import java.io.*;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.text.DateFormat;
-import java.text.FieldPosition;
-import java.text.ParsePosition;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -241,20 +236,10 @@ public class Model {
 
         if (outF.mkdirs()) {
             outputCSV(outP.resolve("out.csv"), iterId, s);
-            outputPopulationParams(outP.resolve("population_params.json"));
+            ParameterWriter.writeParameersToFile(outP.resolve("population_params.json"));
             outputModelParams(outP.resolve("model_params.json"));
-            outputCovidParams(outP.resolve("covid_params.json"));
         } else {
             LOGGER.error("Could not create output directory: " + outP);
-        }
-    }
-
-    private void outputPopulationParams(Path outF) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        try (Writer writer = new FileWriter(outF.toFile())) {
-            gson.toJson(PopulationParameters.get(), writer);
-        } catch (IOException ioException) {
-            ioException.printStackTrace();
         }
     }
 
@@ -267,14 +252,6 @@ public class Model {
         }
     }
 
-    private void outputCovidParams(Path outF) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        try (Writer writer = new FileWriter(outF.toFile())) {
-            gson.toJson(CovidParameters.get(), writer);
-        } catch (IOException ioException) {
-            ioException.printStackTrace();
-        }
-    }
 
     public void outputCSV(Path outF, int startIterID, List<List<DailyStats>> stats) {
     final String[] headers = {"iter", "day", "H", "L", "A", "P1", "P2", "D", "R", "ISeed",

--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -1,21 +1,29 @@
 package uk.co.ramp.covid.simulation;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.co.ramp.covid.simulation.parameters.CovidParameters;
+import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.ImpossibleAllocationException;
 import uk.co.ramp.covid.simulation.population.ImpossibleWorkerDistributionException;
 import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;
 import uk.co.ramp.covid.simulation.util.RNG;
 
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.Reader;
+import java.io.*;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.text.DateFormat;
+import java.text.FieldPosition;
+import java.text.ParsePosition;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 /** A uk.co.ramp.covid.simulation.Model represents a particular run of the model with some given parameters
@@ -59,7 +67,7 @@ public class Model {
     private Integer nDays = null;
     private Integer nIters = null;
     private Integer rngSeed = null;
-    private String outputFile = null;
+    private String outputDirectory = null;
     private Lockdown lockDown = null;
     private Lockdown schoolLockDown = null;
 
@@ -115,8 +123,8 @@ public class Model {
         return this;
     }
 
-    public Model setOutputFile(String fname) {
-        this.outputFile = fname;
+    public Model setOutputDirectory(String fname) {
+        this.outputDirectory = fname;
         return this;
     }
 
@@ -148,8 +156,8 @@ public class Model {
             valid = false;
         }
         if (!outputDisabled) {
-            if (outputFile == null) {
-                LOGGER.warn("Uninitialised model parameter: outputFile");
+            if (outputDirectory == null) {
+                LOGGER.warn("Uninitialised model parameter: outputDirectory");
                 valid = false;
             }
         }
@@ -216,22 +224,66 @@ public class Model {
         }
 
         if (!outputDisabled) {
-            if (outputFile != null) {
-                outputCSV(simulationID, stats);
+            if (outputDirectory != null) {
+                writeOutput(simulationID, stats);
             }
         }
 
         return stats;
     }
+    
+    private void writeOutput(int iterId, List<List<DailyStats>> s) {
+        DateTimeFormatter tsFormatter = DateTimeFormatter.ofPattern("yyyyMMdd_hhmmss");
+        String timeStamp = tsFormatter.format(LocalDateTime.now());
 
-    public void outputCSV(int startIterID, List<List<DailyStats>> stats) {
+        Path outP = FileSystems.getDefault().getPath(outputDirectory, timeStamp);
+        File outF = outP.toFile();
+
+        if (outF.mkdirs()) {
+            outputCSV(outP.resolve("out.csv"), iterId, s);
+            outputPopulationParams(outP.resolve("population_params.json"));
+            outputModelParams(outP.resolve("model_params.json"));
+            outputCovidParams(outP.resolve("covid_params.json"));
+        } else {
+            LOGGER.error("Could not create output directory: " + outP);
+        }
+    }
+
+    private void outputPopulationParams(Path outF) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        try (Writer writer = new FileWriter(outF.toFile())) {
+            gson.toJson(PopulationParameters.get(), writer);
+        } catch (IOException ioException) {
+            ioException.printStackTrace();
+        }
+    }
+
+    private void outputModelParams(Path outF) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        try (Writer writer = new FileWriter(outF.toFile())) {
+            gson.toJson(this, writer);
+        } catch (IOException ioException) {
+            ioException.printStackTrace();
+        }
+    }
+
+    private void outputCovidParams(Path outF) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        try (Writer writer = new FileWriter(outF.toFile())) {
+            gson.toJson(CovidParameters.get(), writer);
+        } catch (IOException ioException) {
+            ioException.printStackTrace();
+        }
+    }
+
+    public void outputCSV(Path outF, int startIterID, List<List<DailyStats>> stats) {
     final String[] headers = {"iter", "day", "H", "L", "A", "P1", "P2", "D", "R", "ISeed",
                               "ICs_W","IHos_W","INur_W","IOff_W","IRes_W","ISch_W","ISho_W","IHome_I",
                               "ICs_V","IHos_V","INur_V","IOff_V","IRes_V","ISch_V","ISho_V","IHome_V",
                               "IAdu","IPen","IChi","IInf",
                               "DAdul","DPen","DChi","DInf", "SecInfections", "GenerationTime" };
         try {
-            FileWriter out = new FileWriter(outputFile);
+            FileWriter out = new FileWriter(outF.toFile());
             CSVPrinter printer = new CSVPrinter(out, CSVFormat.DEFAULT.withHeader(headers));
             for (int i = 0; i < nIters; i++) {
                 for (DailyStats s : stats.get(i)) {

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterWriter.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterWriter.java
@@ -1,0 +1,38 @@
+package uk.co.ramp.covid.simulation.parameters;
+
+import com.google.gson.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.co.ramp.covid.simulation.util.Probability;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Path;
+
+public class ParameterWriter {
+    private static final Logger LOGGER = LogManager.getLogger(ParameterWriter.class);
+
+    private CovidParameters disease;
+    private PopulationParameters population;
+
+    ParameterWriter(CovidParameters c, PopulationParameters p) {
+        disease = c;
+        population = p;
+    }
+
+    public static void writeParameersToFile(Path outF) {
+        GsonBuilder gson = new GsonBuilder().setPrettyPrinting();
+
+        JsonSerializer<Probability> pserializer = (src, typeOfSrc, context) -> new JsonPrimitive(src.asDouble());
+        gson.registerTypeAdapter(Probability.class, pserializer);
+        
+        ParameterWriter params = new ParameterWriter (CovidParameters.get(), PopulationParameters.get());
+
+        try (Writer writer = new FileWriter(outF.toFile())) {
+            gson.create().toJson(params, writer);
+        } catch (IOException e) {
+            LOGGER.error(e);
+        }
+    }
+}

--- a/src/test/resources/test_model_params.json
+++ b/src/test/resources/test_model_params.json
@@ -5,5 +5,5 @@
     "nDays":10,
     "nIters":1,
     "rngSeed":42,
-    "outputFile":"./example.csv"
+    "outputDirectory":"./example.csv"
 }

--- a/src/test/resources/test_model_params_with_no_seed.json
+++ b/src/test/resources/test_model_params_with_no_seed.json
@@ -4,5 +4,5 @@
     "externalInfectionDays":0,
     "nDays":10,
     "nIters":1,
-    "outputFile":"./example.csv"
+    "outputDirectory":"."
 }


### PR DESCRIPTION
This finishes the issue at https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/318 by having runs go to a specified outputDirectory, rather than just a file.

Without the outputDirectory the runs themselves are timestamped (with the end time of the run in yyyymmdd_hhmmss format). Output is in out.csv and the population and model parameters are output.

