### PR TITLE
Add extra output for cross-validation work

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/DailyStats.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/DailyStats.java
@@ -175,6 +175,10 @@ public class DailyStats {
 
     public int getInfantDeaths() { return infantDeaths; }
 
+    public int getTotalDeaths() {
+        return adultDeaths + pensionerDeaths + childDeaths + infantDeaths;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(day, healthy, exposed, asymptomatic, phase1, phase2, dead, recovered,

--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -242,6 +242,7 @@ public class Model {
         
         // By here the output directory will be available
         outputCSV(outP.resolve("out.csv"), iterId, s);
+        extraOutputsForThibaud(outP, s);
         ParameterIO.writeParametersToFile(outP.resolve("population_params.json"));
         outputModelParams(outP.resolve("model_params.json"));
        
@@ -257,7 +258,7 @@ public class Model {
     }
 
 
-    public void outputCSV(Path outF, int startIterID, List<List<DailyStats>> stats) {
+    private void outputCSV(Path outF, int startIterID, List<List<DailyStats>> stats) {
     final String[] headers = {"iter", "day", "H", "L", "A", "P1", "P2", "D", "R", "ISeed",
                               "ICs_W","IHos_W","INur_W","IOff_W","IRes_W","ISch_W","ISho_W","IHome_I",
                               "ICs_V","IHos_V","INur_V","IOff_V","IRes_V","ISch_V","ISho_V","IHome_V",
@@ -272,6 +273,25 @@ public class Model {
                 }
             }
             out.close();
+        } catch (IOException e) {
+            LOGGER.error(e);
+        }
+    }
+
+    private void extraOutputsForThibaud(Path outputDir, List<List<DailyStats>> stats) {
+        try {
+            CSVPrinter dailyInfectionsCSV = new CSVPrinter(new FileWriter(outputDir.resolve("dailyInfections.csv").toFile()), CSVFormat.DEFAULT);
+            CSVPrinter deathsCSV = new CSVPrinter(new FileWriter(outputDir.resolve("deaths.csv").toFile()), CSVFormat.DEFAULT);
+            for (int i = 0; i < nIters; i++) {
+                for (DailyStats s : stats.get(i)) {
+                    dailyInfectionsCSV.print(s.getTotalDailyInfections());
+                    deathsCSV.print(s.getTotalDeaths());
+                }
+                dailyInfectionsCSV.println();
+                deathsCSV.println();
+            }
+            dailyInfectionsCSV.close(true);
+            deathsCSV.close(true);
         } catch (IOException e) {
             LOGGER.error(e);
         }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/CovidParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/CovidParameters.java
@@ -1,9 +1,6 @@
 package uk.co.ramp.covid.simulation.parameters;
 
-import uk.co.ramp.covid.simulation.covid.Covid;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;
-
-import java.util.HashMap;
 
 /**
  * CovidParameters is a singleton class for reading and storing the covid disease parameters

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.DailyStats;
 import uk.co.ramp.covid.simulation.RStats;
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationDistribution;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.*;

--- a/src/main/java/uk/co/ramp/covid/simulation/util/ProbabilityDistribution.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/ProbabilityDistribution.java
@@ -1,7 +1,5 @@
 package uk.co.ramp.covid.simulation.util;
 
-import org.apache.commons.math3.random.RandomDataGenerator;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/test/java/uk/co/ramp/covid/simulation/parameters/CovidParametersTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/parameters/CovidParametersTest.java
@@ -1,8 +1,6 @@
 package uk.co.ramp.covid.simulation.parameters;
 
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.parameters.CovidParameters;
-import uk.co.ramp.covid.simulation.parameters.ParameterIO;
 
 import java.io.IOException;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/parameters/ExampleParametersTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/parameters/ExampleParametersTest.java
@@ -5,9 +5,6 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import uk.co.ramp.covid.simulation.Model;
-import uk.co.ramp.covid.simulation.parameters.CovidParameters;
-import uk.co.ramp.covid.simulation.parameters.ParameterIO;
-import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 
 public class ExampleParametersTest {
 

--- a/src/test/java/uk/co/ramp/covid/simulation/parameters/ParameterIOTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/parameters/ParameterIOTest.java
@@ -2,9 +2,6 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import org.junit.After;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.parameters.CovidParameters;
-import uk.co.ramp.covid.simulation.parameters.ParameterIO;
-import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.util.Probability;
 
 import java.io.IOException;

--- a/src/test/java/uk/co/ramp/covid/simulation/parameters/PopulationParametersTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/parameters/PopulationParametersTest.java
@@ -2,8 +2,6 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import org.junit.After;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.parameters.ParameterIO;
-import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;
 
 import java.io.IOException;


### PR DESCRIPTION
This is a temporary addition, which will soon be replaced by the new data pipeline.  It produces outputs in a format that can be plugged easily into Thibaud's model.  There's more work required before it can be used (e.g. on hospitalization), but this is a start.

See e.g. https://github.com/ScottishCovidResponse/Covid19_EERAModel/blob/dev/test/regression/run1/data/scot_deaths.csv , where the columns are days and rows are health boards.