### PR TITLE
Places are staffed before allocating randomly

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
@@ -43,25 +43,25 @@ public class Adult extends Person {
         CommunalPlace primaryPlace = null;
         switch(profession) {
             case TEACHER: {
-                primaryPlace = p.getRandomSchool();
+                primaryPlace = p.getNextSchoolJob();
             } break;
             case NURSERY: {
-                primaryPlace = p.getRandomNursery();
+                primaryPlace = p.getNextNurseryJob();
             } break;
             case SHOP: {
-                primaryPlace = p.getRandomShop();
+                primaryPlace = p.getNextShopJob();
             } break;
             case CONSTRUCTION: {
-                primaryPlace = p.getRandomConstructionSite();
+                primaryPlace = p.getNextConstructionSiteJob();
             } break;
             case OFFICE: {
-                primaryPlace = p.getRandomOffice();
+                primaryPlace = p.getNextOfficeJob();
             } break;
             case HOSPITAL: {
-                primaryPlace = p.getRandomHospital();
+                primaryPlace = p.getNextHospitalJob();
             } break;
             case RESTAURANT: {
-                primaryPlace = p.getRandomRestaurant();
+                primaryPlace = p.getNextRestaurantJob();
             } break;
             case NONE: {
                 // do nothing


### PR DESCRIPTION
This seems to have been removed in a merge or something.

We now allocate all places with minimum staff first, then we probabilistically allocate the rest of the staff based on place size.