### PR TITLE
Move from Sets to lists for performance

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -13,8 +13,8 @@ public abstract class Place {
 
     // People are managed in 2 lists, those currently in the place "people" and
     // those who will be in the place in the next hour "nextPeople"
-    protected Set<Person> people;
-    protected Set<Person> nextPeople;
+    protected List<Person> people;
+    protected List<Person> nextPeople;
     
     protected double sDistance;
     protected double transConstant;
@@ -24,15 +24,15 @@ public abstract class Place {
     abstract public void reportInfection(Time t, Person p, DailyStats s);
 
     public Place() {
-        this.people = new LinkedHashSet<>();
-        this.nextPeople = new LinkedHashSet<>();
+        this.people = new ArrayList<>();
+        this.nextPeople = new ArrayList<>();
         this.transConstant = PopulationParameters.get().buildingProperties.baseTransmissionConstant;
         this.sDistance = 1.0;
         this.transAdjustment = 1.0;
     }
 
     public List<Person> getPeople() {
-        return new ArrayList<>(people);
+        return people;
     }
 
     public void addPersonNext(Person p) {
@@ -114,7 +114,7 @@ public abstract class Place {
         nextPeople.addAll(people);
 
         // Switch the movement buffers
-        Set<Person> tmp = people;
+        List<Person> tmp = people;
         people = nextPeople;
         nextPeople = tmp;
         nextPeople.clear();


### PR DESCRIPTION
While people/nextPeople is logically a set, moving to Set's causes about a 0.5s slowdown per-day. It's probably not worth this cost.

Most of this is for reproducibility (we need a fixed order, and linked hash-set seems to have quite an overhead to manage the linked list). If we didn't need reproducibility I'm sure a hash-set would be quicker (to keep in mind for later).

Sorry for the jumping around on this issue - I should have checked the performance sooner (we should think about a performance test).