### PR TITLE
Improve Neighbour Movement

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -88,14 +88,22 @@ public abstract class Household extends Place {
     public int sendNeighboursHome(Time t) {
         ArrayList<Person> left = new ArrayList<>();
 
+        final int numInhabitants = getNumInhabitants();
         for (Person p : people) {
-
             if (!isVisitor(p)) {
                 continue;
             }
 
             // People may have already left if their family has
             if (left.contains(p)) {
+                continue;
+            }
+
+            // Go home if the house inhabitants have either left, or were never here
+            if (numInhabitants == 0) {
+                left.add(p);
+                p.returnHome();
+                left.addAll(sendFamilyHome(p, null, t));
                 continue;
             }
 
@@ -117,7 +125,7 @@ public abstract class Household extends Place {
         people.removeAll(left);
         return left.size();
     }
-    
+
     private boolean isVisitor(Person p) {
         return p.getHome() != this;
     }
@@ -144,7 +152,7 @@ public abstract class Household extends Place {
         return ret;
     }
 
-    public int getNumMovers() {
+    public int getNumInhabitants() {
         int n = 0;
         for (Person p : people) {
             if (isInhabitant(p)) {
@@ -186,7 +194,7 @@ public abstract class Household extends Place {
     public void doMovement(Time t, boolean lockdown, Places places) {
         goToHospital(t, places);
 
-        if (!isIsolating() && getNumMovers() > 0) {
+        if (!isIsolating() && getNumInhabitants() > 0) {
             // Ordering here implies work takes highest priority, then shopping trips have higher priority
             // than neighbour and restaurant trips
             moveShift(t, lockdown);

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -16,6 +16,7 @@ import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Probability;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -458,5 +459,36 @@ public class MovementTest extends SimulationTest {
         assertTrue(per.getTestOutcome().get());
         assertTrue(per.getQuarantine());
         assertTrue(iso.isIsolating());
+    }
+
+    @Test
+    public void neighboursShouldLeaveEmptyHouses() {
+        final int simHours = 100;
+        Time t = new Time(0);
+        p = PopulationGenerator.genValidPopulation(populationSize);
+        p.seedVirus(nInfections);
+
+        // Going to an empty neighbours house is okay, but only for 1 hour (when you discover they aren't in)
+        List<Set<Person>> inEmptyNeighbourHouse = new ArrayList<>();
+        DailyStats s = new DailyStats(t);
+        for (int i = 0; i < simHours; i++) {
+            inEmptyNeighbourHouse.add(new HashSet<>());
+
+            p.timeStep(t, s);
+            t = t.advance();
+
+            for (Household h : p.getHouseholds()) {
+                if (h.getNumInhabitants() == 0) {
+                    inEmptyNeighbourHouse.get(i).addAll(h.getVisitors());
+                }
+            }
+
+        }
+
+        for (int i = 0; i < simHours - 1; i++) {
+            for (Person p : inEmptyNeighbourHouse.get(i)) {
+                assertFalse(inEmptyNeighbourHouse.get(i+1).contains(p));
+            }
+        }
     }
 }


### PR DESCRIPTION
This causes neighbours to go home if they either:

1. Go to an empty house
2. Everyone in the house leaves (for work etc).

Also improves the selection of neighbours by making it more random (which should hopefully make it more likely that some of the people that weren't being infected are getting more visitors etc.).

We also allow multiple visits on a visiting day.

I had a look at performance and there's not a massive slowdown if we go back to sampling this hourly rather than daily - if we think this might improve the number of visits etc.