### PR TITLE
More tests

### DIFF
--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -39,6 +39,7 @@ public class ModelTest extends SimulationTest {
     @Test
     public void testBaseLine() {
 
+        Long startTime = System.currentTimeMillis();
         Model m = new Model()
                 .setPopulationSize(population)
                 .setnInitialInfections(nInfections)
@@ -49,6 +50,11 @@ public class ModelTest extends SimulationTest {
                 .setNoOutput();
 
         List<List<DailyStats>> stats = m.run(0);
+
+        //Output model performance
+        double runLength = (System.currentTimeMillis() - startTime)/1000.0;
+        System.out.printf("Total run time (secs): %.3f\n", runLength);
+        System.out.printf("Mean run time per day: %.3f\n", runLength/nDays);
 
         int lastTotalInfected = 10;
         for (DailyStats s : stats.get(0)) {

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -391,7 +391,7 @@ public class MovementTest extends SimulationTest {
             // Count the number of positive and negative tests
             if (p.wasTested()) {
                 numTested++;
-                if (!p.getTestOutcome().get()) {
+
                 if (!p.getTestOutcome()) {
                     numNegative++;
                 } else {

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -1,7 +1,6 @@
 package uk.co.ramp.covid.simulation.integrationTests;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -226,10 +225,11 @@ public class MovementTest extends SimulationTest {
             t = t.advance();
 
             for (CommunalPlace place : p.getPlaces().getAllPlaces()) {
-                // i + 1 since the ith timestep has already been (so we are in the next state)
+                List<Person> staff = place.getStaff(t);
                 if (place.isOpen(day, t.getHour())) {
-                    List<Person> staff = place.getStaff(t);
-                    assertTrue(staff.size() > 0);
+                    assertTrue("No staff found in open place", staff.size() > 0);
+                } else {
+                    assertEquals("Unexpected staff found in closed place", 0, staff.size());
                 }
             }
         }
@@ -371,24 +371,27 @@ public class MovementTest extends SimulationTest {
 
         int numTested = 0;
         int numNegative = 0;
+        int numPositive = 0;
         for (Person p : p.getAllPeople()) {
-            if (p.wasTested()) {
-                numTested++;
-            }
+
             // Only adults/pensioners get tested
             if (p instanceof Child || p instanceof Infant) {
-                assertFalse(p.wasTested());
+                assertFalse("A child was unexpectedly tested", p.wasTested());
             }
 
-            // Some tests are negatives
+            // Count the number of positive and negative tests
             if (p.wasTested()) {
+                numTested++;
                 if (!p.getTestOutcome().get()) {
                     numNegative++;
+                } else {
+                    numPositive++;
                 }
             }
         }
-        assertTrue(numTested > 0);
-        assertTrue(numNegative > 0);
+        assertTrue("No-one was tested", numTested > 0);
+        assertTrue("No-one tested negative", numNegative > 0);
+        assertEquals("Unexpected number of positive tests", numTested - numNegative, numPositive);
     }
 
     @Test

--- a/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
@@ -15,7 +15,7 @@ public class RStatsTest extends SimulationTest {
 
     @Before
     public void setupParams() {
-        int populationSize = 10000;
+        int populationSize = 50000;
         pop = PopulationGenerator.genValidPopulation(populationSize);
     }
 
@@ -42,12 +42,9 @@ public class RStatsTest extends SimulationTest {
         assertTrue("Mean generation time unexpectedly = 0", rs.getMeanGenerationTime(0) > 0);
     }
 
-    //This test consistently fails. Peak R value always occurs more than 5 days after lockdown has started.
-    //Not sure if this is a failing of the test or a failing of the model.
-    @Ignore
-    @Test
     public void testMeanRWithLockdown() {
-
+        int populationSize = 50000;
+        pop = PopulationGenerator.genValidPopulation(populationSize);
         int startLock = 30;
         int endLock = 90;
         int nDays = 90;
@@ -65,5 +62,6 @@ public class RStatsTest extends SimulationTest {
                 assertTrue("Peak R occurred at Day " + i, rs.getMeanRBefore(i + 1) < peakR);
             }
         }
+
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
@@ -42,7 +42,7 @@ public class RStatsTest extends SimulationTest {
         assertTrue("Mean generation time unexpectedly = 0", rs.getMeanGenerationTime(0) > 0);
     }
 
-    //This test consistently fails. Peak R value always occurs more thsn 5 days after lockdown has started.
+    //This test consistently fails. Peak R value always occurs more than 5 days after lockdown has started.
     //Not sure if this is a failing of the test or a failing of the model.
     @Ignore
     @Test
@@ -62,7 +62,7 @@ public class RStatsTest extends SimulationTest {
             if (i < startLock) peakR = Math.max(peakR, rs.getMeanRBefore(i + 1));
             //Test that the R value during lockdown is always below the peak R
             if (i > startLock + 5) {
-                assertTrue("Peak R occurred at Day " + i, rs.getMeanRBefore(i + 1) > peakR);
+                assertTrue("Peak R occurred at Day " + i, rs.getMeanRBefore(i + 1) < peakR);
             }
         }
     }

--- a/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
@@ -1,6 +1,7 @@
 package uk.co.ramp.covid.simulation.output;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
@@ -41,4 +42,28 @@ public class RStatsTest extends SimulationTest {
         assertTrue("Mean generation time unexpectedly = 0", rs.getMeanGenerationTime(0) > 0);
     }
 
+    //This test consistently fails. Peak R value always occurs more thsn 5 days after lockdown has started.
+    //Not sure if this is a failing of the test or a failing of the model.
+    @Ignore
+    @Test
+    public void testMeanRWithLockdown() {
+
+        int startLock = 30;
+        int endLock = 90;
+        int nDays = 90;
+        pop.seedVirus(10);
+        pop.setLockdown(startLock, endLock, 2.0);
+        pop.simulate(nDays);
+        RStats rs = new RStats(pop);
+        double peakR = 0.0;
+
+        for (int i = 0; i < nDays; i++) {
+            //Get the peak R value before lockdown starts
+            if (i < startLock) peakR = Math.max(peakR, rs.getMeanRBefore(i + 1));
+            //Test that the R value during lockdown is always below the peak R
+            if (i > startLock + 5) {
+                assertTrue("Peak R occurred at Day " + i, rs.getMeanRBefore(i + 1) > peakR);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Updated a movement test, added a performance test and a test to check that R peaks before lockdown. This test consistently fails with the peak R occurring 15 days after lockdown starts. I'm not sure if this is a problem with the test or the model.