### PR TITLE
Allocate neighbours from groups

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -4,6 +4,7 @@ import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
+import uk.co.ramp.covid.simulation.place.householdtypes.NeighbourGroup;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.RNG;
@@ -410,6 +411,7 @@ public abstract class Household extends Place implements Home {
     public abstract boolean additionalPensionersAllowed();
     public abstract boolean adultAnyAgeRequired();
     public abstract boolean additionalAdultAnyAgeAllowed();
+    public abstract NeighbourGroup getNeighbourGroup();
 
     public void addAdult(Adult p) {
         if (adultRequired() || additionalAdultsAllowed()

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/AdultPensioner.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/AdultPensioner.java
@@ -49,4 +49,9 @@ public class AdultPensioner extends Household {
     public boolean additionalAdultAnyAgeAllowed() {
         return false;
     }
+
+    @Override
+    public NeighbourGroup getNeighbourGroup() {
+        return NeighbourGroup.PENSIONER;
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/DoubleOlder.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/DoubleOlder.java
@@ -49,4 +49,9 @@ public class DoubleOlder extends Household {
     public boolean additionalAdultAnyAgeAllowed() {
         return false;
     }
+
+    @Override
+    public NeighbourGroup getNeighbourGroup() {
+        return NeighbourGroup.PENSIONER;
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/LargeAdult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/LargeAdult.java
@@ -1,6 +1,7 @@
 package uk.co.ramp.covid.simulation.place.householdtypes;
 
 import uk.co.ramp.covid.simulation.place.Household;
+import uk.co.ramp.covid.simulation.population.Adult;
 import uk.co.ramp.covid.simulation.population.Places;
 
 /** LargeAdult: Three or more adults (any age) and no children */
@@ -46,5 +47,10 @@ public class LargeAdult extends Household {
     @Override
     public boolean additionalAdultAnyAgeAllowed() {
         return true;
+    }
+
+    @Override
+    public NeighbourGroup getNeighbourGroup() {
+        return NeighbourGroup.ADULT;
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/LargeManyAdultFamily.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/LargeManyAdultFamily.java
@@ -49,4 +49,9 @@ public class LargeManyAdultFamily extends Household {
     public boolean additionalAdultAnyAgeAllowed() {
         return true;
     }
+
+    @Override
+    public NeighbourGroup getNeighbourGroup() {
+        return NeighbourGroup.FAMILY;
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/LargeTwoAdultFamily.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/LargeTwoAdultFamily.java
@@ -49,4 +49,9 @@ public class LargeTwoAdultFamily extends Household {
     public boolean additionalAdultAnyAgeAllowed() {
         return false;
     }
+
+    @Override
+    public NeighbourGroup getNeighbourGroup() {
+        return NeighbourGroup.FAMILY;
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/NeighbourGroup.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/NeighbourGroup.java
@@ -1,0 +1,5 @@
+package uk.co.ramp.covid.simulation.place.householdtypes;
+
+public enum NeighbourGroup {
+    ADULT, FAMILY, PENSIONER
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/SingleAdult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/SingleAdult.java
@@ -49,4 +49,9 @@ public class SingleAdult extends Household {
     public boolean additionalAdultAnyAgeAllowed() {
         return false;
     }
+
+    @Override
+    public NeighbourGroup getNeighbourGroup() {
+        return NeighbourGroup.ADULT;
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/SingleOlder.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/SingleOlder.java
@@ -49,4 +49,9 @@ public class SingleOlder extends Household {
     public boolean additionalAdultAnyAgeAllowed() {
         return false;
     }
+
+    @Override
+    public NeighbourGroup getNeighbourGroup() {
+        return NeighbourGroup.PENSIONER;
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/SingleParent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/SingleParent.java
@@ -49,4 +49,9 @@ public class SingleParent extends Household {
     public boolean additionalAdultAnyAgeAllowed() {
         return false;
     }
+
+    @Override
+    public NeighbourGroup getNeighbourGroup() {
+        return NeighbourGroup.FAMILY;
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/SmallAdult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/SmallAdult.java
@@ -49,4 +49,9 @@ public class SmallAdult extends Household {
     public boolean additionalAdultAnyAgeAllowed() {
         return false;
     }
+
+    @Override
+    public NeighbourGroup getNeighbourGroup() {
+        return NeighbourGroup.ADULT;
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/SmallFamily.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/householdtypes/SmallFamily.java
@@ -49,4 +49,9 @@ public class SmallFamily extends Household {
     public boolean additionalAdultAnyAgeAllowed() {
         return false;
     }
+
+    @Override
+    public NeighbourGroup getNeighbourGroup() {
+        return NeighbourGroup.FAMILY;
+    }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -325,6 +325,7 @@ public class MovementTest extends SimulationTest {
     @Test
     public void newInfectionsResetIsolationTimer() {
         int daysIsolated = 2;
+        CovidParameters.get().testParameters.pDiagnosticTestAvailable = new Probability(0.0);
 
         Time t = new Time(24);
         DailyStats s = new DailyStats(t);

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -355,4 +355,23 @@ public class PopulationTest extends SimulationTest {
 
         assertTrue(child > infant);
     }
+
+    @Test
+    public void neighbourDistributionsAreBasedOnHouseholdTypes() {
+        int sameGroup = 0;
+        int otherGroups = 0;
+        
+        for (Household h : pop.getHouseholds()) {
+            for (Household o : h.getNeighbours()) {
+                if (h.getNeighbourGroup() == o.getNeighbourGroup()) {
+                    sameGroup++;
+                } else {
+                    otherGroups++;
+                }
+            }
+        }
+        
+        assertTrue("Neighbours of the same group should be more than other groups: " + sameGroup + ">" + otherGroups,
+                sameGroup > otherGroups);
+    }
 }


### PR DESCRIPTION
This implements https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/456 by drawing sets of neighbours from a probability distribution rather than fully randomly. 