### PR TITLE
Add School Holidays

### DIFF
--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -178,7 +178,10 @@
             "pOfficeKey":0.5,
             "pShopKey":0.5,
             "pLeaveShop": 0.5,
-            "pLeaveRestaurant": 0.4
+            "pLeaveRestaurant": 0.4,
+            "schoolHolidays": [
+                { "start": 28, "end": 32 }
+            ]
         },
         "infantProperties":{
             "pAttendsNursery":0.12

--- a/src/main/java/uk/co/ramp/covid/simulation/DateRange.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/DateRange.java
@@ -1,5 +1,9 @@
 package uk.co.ramp.covid.simulation;
 
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializer;
+
 public class DateRange {
     final Time start;
     final Time end;
@@ -20,4 +24,18 @@ public class DateRange {
     public Time getEnd() {
         return end;
     }
+
+    public static JsonSerializer<DateRange> serializer = (src, typeOfSrc, context) -> {
+        JsonObject o = new JsonObject();
+        o.addProperty("start", src.getStart().getAbsDay());
+        o.addProperty("end", src.getEnd().getAbsDay());
+        return o;
+    };
+
+    public static JsonDeserializer<DateRange> deserializer = (json, typeOfT, context) -> {
+        JsonObject o = json.getAsJsonObject();
+        int s = o.get("start").getAsInt();
+        int e = o.get("end").getAsInt();
+        return new DateRange(Time.timeFromDay(s), Time.timeFromDay(e));
+    };
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/DateRange.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/DateRange.java
@@ -1,0 +1,23 @@
+package uk.co.ramp.covid.simulation;
+
+public class DateRange {
+    final Time start;
+    final Time end;
+    
+    public DateRange(Time start, Time end) {
+        this.start = start;
+        this.end = end;
+    }
+    
+    public boolean inRange(Time t) {
+        return start.compareTo(t) <= 0 && end.compareTo(t) > 0;
+    }
+
+    public Time getStart() {
+        return start;
+    }
+
+    public Time getEnd() {
+        return end;
+    }
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/covid/Covid.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/covid/Covid.java
@@ -5,7 +5,7 @@
 package uk.co.ramp.covid.simulation.covid;
 
 import org.apache.commons.math3.random.RandomDataGenerator;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.util.Probability;

--- a/src/main/java/uk/co/ramp/covid/simulation/covid/InfectionLog.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/covid/InfectionLog.java
@@ -1,6 +1,6 @@
 package uk.co.ramp.covid.simulation.covid;
 
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.Person;
 
 import java.util.HashSet;

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownController.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownController.java
@@ -1,6 +1,6 @@
 package uk.co.ramp.covid.simulation.lockdown;
 
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.place.CommunalPlace;
 import uk.co.ramp.covid.simulation.place.Nursery;
 import uk.co.ramp.covid.simulation.place.School;

--- a/src/main/java/uk/co/ramp/covid/simulation/output/DailyStats.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/DailyStats.java
@@ -3,7 +3,7 @@ package uk.co.ramp.covid.simulation.output;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.*;
 
 import java.io.IOException;

--- a/src/main/java/uk/co/ramp/covid/simulation/output/NetworkGenerator.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/NetworkGenerator.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.place.Place;
 import uk.co.ramp.covid.simulation.population.Person;
 

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/BuildingProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/BuildingProperties.java
@@ -1,6 +1,6 @@
 package uk.co.ramp.covid.simulation.parameters;
 
-import uk.co.ramp.covid.simulation.DateRange;
+import uk.co.ramp.covid.simulation.util.DateRange;
 import uk.co.ramp.covid.simulation.util.Probability;
 
 import java.util.List;

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/BuildingProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/BuildingProperties.java
@@ -1,6 +1,9 @@
 package uk.co.ramp.covid.simulation.parameters;
 
+import uk.co.ramp.covid.simulation.DateRange;
 import uk.co.ramp.covid.simulation.util.Probability;
+
+import java.util.List;
 
 public class BuildingProperties {
     public Double baseTransmissionConstant = null;
@@ -21,4 +24,5 @@ public class BuildingProperties {
     public Probability pLeaveShop = null;
     public Probability pLeaveRestaurant = null;
     public Probability pHospitalStaffWillFurlough = null;
+    public List<DateRange> schoolHolidays = null;
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterIO.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterIO.java
@@ -3,7 +3,7 @@ package uk.co.ramp.covid.simulation.parameters;
 import com.google.gson.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.co.ramp.covid.simulation.DateRange;
+import uk.co.ramp.covid.simulation.util.DateRange;
 import uk.co.ramp.covid.simulation.util.Probability;
 
 import java.io.*;

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterIO.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterIO.java
@@ -4,8 +4,6 @@ import com.google.gson.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.DateRange;
-import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.util.InvalidProbabilityException;
 import uk.co.ramp.covid.simulation.util.Probability;
 
 import java.io.*;
@@ -28,27 +26,8 @@ public class ParameterIO {
         Reader file = new FileReader(path);
         GsonBuilder gson = new GsonBuilder();
 
-        JsonDeserializer<Probability> pdeserializer = (json, typeOfT, context) -> {
-            double p = json.getAsDouble();
-            try {
-                return new Probability(p);
-            } catch (InvalidProbabilityException e) {
-                LOGGER.error(e);
-                // There doesn't seem to be a way to get the field name here
-                // Instead we return null and let the paramterInitiasedChecker print the error
-                return null;
-            }
-        };
-
-        JsonDeserializer<DateRange> dateRangeDeserializer = (json, typeOfT, context) -> {
-            JsonObject o = json.getAsJsonObject();
-            int s = o.get("start").getAsInt();
-            int e = o.get("end").getAsInt();
-            return new DateRange(Time.timeFromDay(s), Time.timeFromDay(e));
-        };
-
-        gson.registerTypeAdapter(Probability.class, pdeserializer);
-        gson.registerTypeAdapter(DateRange.class, dateRangeDeserializer);
+        gson.registerTypeAdapter(Probability.class, Probability.deserializer);
+        gson.registerTypeAdapter(DateRange.class, DateRange.deserializer);
         ParameterIO r = gson.create().fromJson(file, ParameterIO.class);
 
         CovidParameters.setParameters(r.disease);
@@ -58,17 +37,8 @@ public class ParameterIO {
     public static void writeParametersToFile(Path outF) {
         GsonBuilder gson = new GsonBuilder().setPrettyPrinting();
 
-        JsonSerializer<Probability> pserializer = (src, typeOfSrc, context) -> new JsonPrimitive(src.asDouble());
-
-        JsonSerializer<DateRange> dateRangeSerializer = (src, typeOfSrc, context) -> {
-            JsonObject o = new JsonObject();
-            o.addProperty("start", src.getStart().getAbsDay());
-            o.addProperty("end", src.getEnd().getAbsDay());
-            return o;
-        };
-
-        gson.registerTypeAdapter(Probability.class, pserializer);
-        gson.registerTypeAdapter(DateRange.class, dateRangeSerializer);
+        gson.registerTypeAdapter(Probability.class, Probability.serializer);
+        gson.registerTypeAdapter(DateRange.class, DateRange.serializer);
 
         ParameterIO params = new ParameterIO(CovidParameters.get(), PopulationParameters.get());
 

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterIO.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterIO.java
@@ -3,6 +3,8 @@ package uk.co.ramp.covid.simulation.parameters;
 import com.google.gson.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.co.ramp.covid.simulation.DateRange;
+import uk.co.ramp.covid.simulation.Time;
 import uk.co.ramp.covid.simulation.util.InvalidProbabilityException;
 import uk.co.ramp.covid.simulation.util.Probability;
 
@@ -38,7 +40,15 @@ public class ParameterIO {
             }
         };
 
+        JsonDeserializer<DateRange> dateRangeDeserializer = (json, typeOfT, context) -> {
+            JsonObject o = json.getAsJsonObject();
+            int s = o.get("start").getAsInt();
+            int e = o.get("end").getAsInt();
+            return new DateRange(Time.timeFromDay(s), Time.timeFromDay(e));
+        };
+
         gson.registerTypeAdapter(Probability.class, pdeserializer);
+        gson.registerTypeAdapter(DateRange.class, dateRangeDeserializer);
         ParameterIO r = gson.create().fromJson(file, ParameterIO.class);
 
         CovidParameters.setParameters(r.disease);
@@ -49,7 +59,16 @@ public class ParameterIO {
         GsonBuilder gson = new GsonBuilder().setPrettyPrinting();
 
         JsonSerializer<Probability> pserializer = (src, typeOfSrc, context) -> new JsonPrimitive(src.asDouble());
+
+        JsonSerializer<DateRange> dateRangeSerializer = (src, typeOfSrc, context) -> {
+            JsonObject o = new JsonObject();
+            o.addProperty("start", src.getStart().getAbsDay());
+            o.addProperty("end", src.getEnd().getAbsDay());
+            return o;
+        };
+
         gson.registerTypeAdapter(Probability.class, pserializer);
+        gson.registerTypeAdapter(DateRange.class, dateRangeSerializer);
 
         ParameterIO params = new ParameterIO(CovidParameters.get(), PopulationParameters.get());
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CareHome.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CareHome.java
@@ -1,6 +1,6 @@
 package uk.co.ramp.covid.simulation.place;
 
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -5,8 +5,8 @@
 package uk.co.ramp.covid.simulation.place;
 
 import org.apache.commons.math3.random.RandomDataGenerator;
-import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.DateRange;
+import uk.co.ramp.covid.simulation.util.Time;
+import uk.co.ramp.covid.simulation.util.DateRange;
 import uk.co.ramp.covid.simulation.population.CStatus;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.Places;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -6,7 +6,7 @@ package uk.co.ramp.covid.simulation.place;
 
 import org.apache.commons.math3.random.RandomDataGenerator;
 import uk.co.ramp.covid.simulation.Time;
-import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
+import uk.co.ramp.covid.simulation.DateRange;
 import uk.co.ramp.covid.simulation.population.CStatus;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.Places;
@@ -15,7 +15,9 @@ import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 public abstract class CommunalPlace extends Place {
@@ -34,18 +36,19 @@ public abstract class CommunalPlace extends Place {
     protected final RandomDataGenerator rng;
     
     public abstract Shifts getShifts();
-
+    protected Set<DateRange> holidays;
+    
     public CommunalPlace(Size s) {
         this();
         size = s;
     }
-
 
     public CommunalPlace() {
         super();
         this.rng = RNG.get();
         this.times = new OpeningTimes(8,17,1,5, OpeningTimes.getAllDays());
         this.keyPremises = false;
+        setHolidays();
     }
 
     public void overrideKeyPremises(boolean overR) {
@@ -122,7 +125,7 @@ public abstract class CommunalPlace extends Place {
                 continue;
             }
 
-            if (pLeave.sample() || !times.isOpenNextHour(t)) {
+            if (pLeave.sample() || !isOpenNextHour(t)) {
                 p.returnHome(this);
                 sendFamilyHome(p, this, t);
             } else {
@@ -138,18 +141,25 @@ public abstract class CommunalPlace extends Place {
     }
     
     public boolean isVisitorOpenNextHour(Time t) {
-        return  times.getOpenDays().get(t.getDay())
-                && t.getHour() + 1 >= times.getVisitorOpen()
-                && t.getHour() + 1 < times.getVisitorClose();
+        return isOpenNextHour(t) && times.isOpenToVisitors(t.advance());
+    }
+    
+    public boolean isOpenNextHour(Time t) {
+        return isOpen(t.advance());
     }
 
-    public boolean isOpen(int day, int hour) {
-        if (!times.getOpenDays().get(day)) {
+    public boolean isOpen(Time t) {
+        for (DateRange holiday : holidays) {
+            if (holiday.inRange(t)) {
+                return false;
+            }
+        }
+
+        if (!times.getOpenDays().get(t.getDay())) {
             return false;
         }
 
-        return hour >= times.getOpen()
-                && hour < times.getClose();
+        return t.getHour() >= times.getOpen() && t.getHour() < times.getClose();
     }
 
     public List<Person> getStaff(Time t) {
@@ -179,4 +189,8 @@ public abstract class CommunalPlace extends Place {
     public abstract boolean isFullyStaffed();
 
     public OpeningTimes getTimes() { return times; }
+    
+    public void setHolidays() {
+        holidays = new HashSet<>();
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -15,9 +15,7 @@ import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 
 public abstract class CommunalPlace extends Place {
@@ -36,7 +34,7 @@ public abstract class CommunalPlace extends Place {
     protected final RandomDataGenerator rng;
     
     public abstract Shifts getShifts();
-    protected Set<DateRange> holidays;
+    protected List<DateRange> holidays;
     
     public CommunalPlace(Size s) {
         this();
@@ -187,6 +185,6 @@ public abstract class CommunalPlace extends Place {
     public OpeningTimes getTimes() { return times; }
     
     public void setHolidays() {
-        holidays = new HashSet<>();
+        holidays = new ArrayList<>();
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -155,11 +155,7 @@ public abstract class CommunalPlace extends Place {
             }
         }
 
-        if (!times.getOpenDays().get(t.getDay())) {
-            return false;
-        }
-
-        return t.getHour() >= times.getOpen() && t.getHour() < times.getClose();
+        return times.isOpen(t);
     }
 
     public List<Person> getStaff(Time t) {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
@@ -1,7 +1,7 @@
 package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.Shifts;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -1,7 +1,7 @@
 package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -1,7 +1,7 @@
 package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.householdtypes.NeighbourGroup;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
@@ -1,7 +1,7 @@
 package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.Shifts;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -1,7 +1,7 @@
 package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.Shifts;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/OpeningTimes.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/OpeningTimes.java
@@ -1,6 +1,6 @@
 package uk.co.ramp.covid.simulation.place;
 
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 
 import java.util.BitSet;
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/OpeningTimes.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/OpeningTimes.java
@@ -28,12 +28,12 @@ public class OpeningTimes {
         this(open, close, open, close, days);
     }
     
-    public boolean isOpen(int time, int day) {
-        return time >= open && time < close && openDays.get(day);
+    public boolean isOpen(Time t) {
+        return openDays.get(t.getDay()) && t.getHour() >= open && t.getHour() < close;
     }
 
-    public boolean isOpenToVisitors(int time, int day) {
-        return time >= visitorOpen && time < visitorClose && openDays.get(day);
+    public boolean isOpenToVisitors(Time t) {
+        return openDays.get(t.getDay()) && t.getHour() >= visitorOpen && t.getHour() < visitorClose;
     }
 
     public int getOpen() {
@@ -124,7 +124,4 @@ public class OpeningTimes {
         return new OpeningTimes(0,24, OpeningTimes.getAllDays());
     }
 
-    public boolean isOpenNextHour(Time t) {
-        return isOpen(t.getHour() + 1, t.getDay());
-    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -2,7 +2,7 @@ package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.output.NetworkGenerator;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.CStatus;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -1,15 +1,13 @@
 package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.Places;
 import uk.co.ramp.covid.simulation.population.Shifts;
 import uk.co.ramp.covid.simulation.util.RNG;
 import uk.co.ramp.covid.simulation.util.RoundRobinAllocator;
-
-import java.util.Iterator;
 
 public class Restaurant extends CommunalPlace {
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -6,7 +6,7 @@ import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.Shifts;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 
 public class School extends CommunalPlace {
 
@@ -39,7 +39,7 @@ public class School extends CommunalPlace {
 
     @Override
     public void setHolidays() {
-        holidays = new HashSet<>();
+        holidays = new ArrayList<>();
         holidays.addAll(PopulationParameters.get().buildingProperties.schoolHolidays);
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -1,7 +1,7 @@
 package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.Shifts;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -6,6 +6,8 @@ import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.Shifts;
 
+import java.util.HashSet;
+
 public class School extends CommunalPlace {
 
     public School(Size s) {
@@ -33,6 +35,12 @@ public class School extends CommunalPlace {
     @Override
     public boolean isFullyStaffed() {
         return nStaff > 0;
+    }
+
+    @Override
+    public void setHolidays() {
+        holidays = new HashSet<>();
+        holidays.addAll(PopulationParameters.get().buildingProperties.schoolHolidays);
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -1,11 +1,10 @@
 package uk.co.ramp.covid.simulation.place;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.Places;
-import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.population.Shifts;
 import uk.co.ramp.covid.simulation.util.RoundRobinAllocator;
 

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
@@ -1,6 +1,6 @@
 package uk.co.ramp.covid.simulation.population;
 
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -8,7 +8,7 @@ import org.apache.commons.math3.random.RandomDataGenerator;
 import uk.co.ramp.covid.simulation.covid.Covid;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.CareHome;
 import uk.co.ramp.covid.simulation.place.CommunalPlace;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -255,7 +255,8 @@ public abstract class Person {
 
 
     public boolean worksNextHour(CommunalPlace communalPlace, Time t, boolean lockdown) {
-        if (primaryPlace == null || shifts == null || primaryPlace != communalPlace) {
+        if (primaryPlace == null || shifts == null || primaryPlace != communalPlace
+                || !communalPlace.isOpenNextHour(t)) {
             return false;
         }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.lockdown.LockdownController;
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.output.RStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.HouseholdProperties;
 import uk.co.ramp.covid.simulation.parameters.PopulationDistribution;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;

--- a/src/main/java/uk/co/ramp/covid/simulation/util/DateRange.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/DateRange.java
@@ -1,4 +1,4 @@
-package uk.co.ramp.covid.simulation;
+package uk.co.ramp.covid.simulation.util;
 
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonObject;

--- a/src/main/java/uk/co/ramp/covid/simulation/util/Probability.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/Probability.java
@@ -1,7 +1,15 @@
 package uk.co.ramp.covid.simulation.util;
 
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class Probability {
-    double p;
+    private static final Logger LOGGER = LogManager.getLogger(Probability.class);
+
+    private double p;
 
     public Probability(double p) {
         set(p);
@@ -19,4 +27,19 @@ public class Probability {
     public boolean sample() {
         return RNG.get().nextUniform(0.0,1.0) < p;
     }
+
+    public static JsonDeserializer<Probability> deserializer = (json, typeOfT, context) -> {
+        double p = json.getAsDouble();
+        try {
+            return new Probability(p);
+        } catch (InvalidProbabilityException e) {
+            LOGGER.error(e);
+            // There doesn't seem to be a way to get the field name here
+            // Instead we return null and let the paramterInitiasedChecker print the error
+            return null;
+        }
+    };
+
+    public static JsonSerializer<Probability> serializer =
+            (src, typeOfSrc, context) -> new JsonPrimitive(src.asDouble());
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/util/Time.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/Time.java
@@ -1,4 +1,4 @@
-package uk.co.ramp.covid.simulation;
+package uk.co.ramp.covid.simulation.util;
 
 import java.util.Objects;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/DateRangeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/DateRangeTest.java
@@ -1,6 +1,8 @@
 package uk.co.ramp.covid.simulation;
 
 import org.junit.Test;
+import uk.co.ramp.covid.simulation.util.DateRange;
+import uk.co.ramp.covid.simulation.util.Time;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/DateRangeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/DateRangeTest.java
@@ -1,0 +1,21 @@
+package uk.co.ramp.covid.simulation;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DateRangeTest {
+    
+    @Test
+    public void inRange() {
+        DateRange d = new DateRange( Time.timeFromDay(1),Time.timeFromDay(3));
+        assertTrue(d.inRange(Time.timeFromDay(1)));
+        assertTrue(d.inRange(Time.timeFromDay(2)));
+        assertFalse(d.inRange(Time.timeFromDay(3)));
+        assertFalse(d.inRange(Time.timeFromDay(0)));
+        assertFalse(d.inRange(Time.timeFromDay(4)));
+        assertFalse(d.inRange(Time.timeFromDay(3).advance()));
+    }
+
+
+}

--- a/src/test/java/uk/co/ramp/covid/simulation/TimeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/TimeTest.java
@@ -1,6 +1,7 @@
 package uk.co.ramp.covid.simulation;
 
 import org.junit.Test;
+import uk.co.ramp.covid.simulation.util.Time;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/covid/CovidTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/covid/CovidTest.java
@@ -2,7 +2,7 @@ package uk.co.ramp.covid.simulation.covid;
 
 import org.junit.After;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.Household;

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -234,7 +234,7 @@ public class MovementTest extends SimulationTest {
 
             for (CommunalPlace place : p.getPlaces().getAllPlaces()) {
                 List<Person> staff = place.getStaff(t);
-                if (place.isOpen(day, t.getHour())) {
+                if (place.isOpen(t)) {
                     assertTrue("No staff found in open place", staff.size() > 0);
                 } else {
                     assertEquals("Unexpected staff found in closed place", 0, staff.size());

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.*;

--- a/src/test/java/uk/co/ramp/covid/simulation/lockdown/LockdownControllerTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/lockdown/LockdownControllerTest.java
@@ -1,9 +1,8 @@
 package uk.co.ramp.covid.simulation.lockdown;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.place.Nursery;
 import uk.co.ramp.covid.simulation.place.School;
 import uk.co.ramp.covid.simulation.population.Population;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/CareHomeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/CareHomeTest.java
@@ -2,7 +2,7 @@ package uk.co.ramp.covid.simulation.place;
 
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.Model;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/CommunalPlaceTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/CommunalPlaceTest.java
@@ -57,9 +57,9 @@ public class CommunalPlaceTest extends SimulationTest {
     private void testShopOrRestaurant(CommunalPlace place, int open, int close, int day) {
         //Test if shop or restaurant is open or closed
         if (t.getHour() >= open && t.getHour() < close) {
-            assertTrue("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly closed", place.isOpen(day, t.getHour()));
+            assertTrue("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly closed", place.isOpen(t));
         } else {
-            assertFalse("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly open", place.isOpen(day, t.getHour()));
+            assertFalse("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly open", place.isOpen(t));
         }
 
         //Test if shop or restaurant is open to visitors in the next hour
@@ -73,23 +73,23 @@ public class CommunalPlaceTest extends SimulationTest {
     private void testOfficeHours(CommunalPlace place, int open, int close, int day) {
         //Test if place with 9-5 hours is open or closed
         if (t.getHour() >= open && t.getHour() < close && day < 5) {
-            assertTrue("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly closed", place.isOpen(day, t.getHour()));
+            assertTrue("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly closed", place.isOpen(t));
         } else {
-            assertFalse("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly open", place.isOpen(day, t.getHour()));
+            assertFalse("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly open", place.isOpen(t));
         }
     }
 
 
     private void testCarehome(CommunalPlace place, int open, int close, int day) {
         if (t.getHour() >= open && t.getHour() < close) {
-            assertTrue("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly closed", place.isOpen(day, t.getHour()));
+            assertTrue("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly closed", place.isOpen(t));
         } else {
-            assertFalse("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly open", place.isOpen(day, t.getHour()));
+            assertFalse("Day " + day + " Time " + t.getHour() + " " + place.toString() + " unexpectedly open", place.isOpen(t));
         }
     }
 
     private void testHospital(CommunalPlace place, int day) {
         // Hospitals should always be open
-        assertTrue("Day " + day + " Time " + t.getHour() + " Hospital unexpectedly closed", place.isOpen(day, t.getHour()));
+        assertTrue("Day " + day + " Time " + t.getHour() + " Hospital unexpectedly closed", place.isOpen(t));
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/place/CommunalPlaceTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/CommunalPlaceTest.java
@@ -3,7 +3,7 @@ package uk.co.ramp.covid.simulation.place;
 import org.junit.Before;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.ImpossibleWorkerDistributionException;
 import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonParseException;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.Model;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonParseException;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.Model;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.*;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HouseholdTest.java
@@ -7,7 +7,7 @@ import com.google.gson.JsonParseException;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.Model;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.place.householdtypes.LargeManyAdultFamily;
 import uk.co.ramp.covid.simulation.place.householdtypes.SingleAdult;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.householdtypes.SmallFamily;
 import uk.co.ramp.covid.simulation.population.*;
@@ -14,7 +14,6 @@ import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Probability;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -96,7 +96,7 @@ public class SchoolTest extends SimulationTest {
         }
         checkSchoolsPopulated(p);
 
-        // Day 1 - still open
+        // Day 1 - open
         for (int i = 0; i < 24; i++) {
             p.timeStep(t, new DailyStats(t));
             t = t.advance();
@@ -110,14 +110,14 @@ public class SchoolTest extends SimulationTest {
         }
         checkSchoolsNotPopulated(p);
 
-        // Day 3 - holiday
+        // Day 3 - open
         for (int i = 0; i < 24; i++) {
             p.timeStep(t, new DailyStats(t));
             t = t.advance();
         }
         checkSchoolsPopulated(p);
 
-        // Day 4 - open again
+        // Day 4 - holiday
         for (int i = 0; i < 24; i++) {
             p.timeStep(t, new DailyStats(t));
             t = t.advance();

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -2,9 +2,9 @@ package uk.co.ramp.covid.simulation.place;
 
 
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.DateRange;
+import uk.co.ramp.covid.simulation.util.DateRange;
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -2,6 +2,7 @@ package uk.co.ramp.covid.simulation.place;
 
 
 import org.junit.Test;
+import uk.co.ramp.covid.simulation.DateRange;
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
@@ -9,10 +10,10 @@ import uk.co.ramp.covid.simulation.population.*;
 import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class SchoolTest extends SimulationTest {
 
@@ -61,6 +62,67 @@ public class SchoolTest extends SimulationTest {
             }
 
         }
+    }
+    
+    private void checkSchoolsPopulated(Population p) {
+        for (School s : p.getPlaces().getSchools()) {
+            assertNotEquals(0, s.getNumPeople());
+        }
+    }
+
+    private void checkSchoolsNotPopulated(Population p) {
+        for (School s : p.getPlaces().getSchools()) {
+            assertEquals(0, s.getNumPeople());
+        }
+    }
+
+    @Test
+    public void schoolsCanTakeHolidays() {
+        List<DateRange> holidays = new ArrayList<>();
+
+        // Holidays are non-inclusive
+        holidays.add(new DateRange(Time.timeFromDay(2), Time.timeFromDay(3)));
+        holidays.add(new DateRange(Time.timeFromDay(4), Time.timeFromDay(5)));
+        PopulationParameters.get().buildingProperties.schoolHolidays = holidays;
+        
+        int populationSize = 10000;
+        Population p = PopulationGenerator.genValidPopulation(populationSize);
+        
+        // Schools are open at midday so we sample then
+        Time t = new Time(0);
+        for (int i = 0; i < 12; i++) {
+            p.timeStep(t, new DailyStats(t));
+            t = t.advance();
+        }
+        checkSchoolsPopulated(p);
+
+        // Day 1 - still open
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(t, new DailyStats(t));
+            t = t.advance();
+        }
+        checkSchoolsPopulated(p);
+
+        // Day 2 - holiday
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(t, new DailyStats(t));
+            t = t.advance();
+        }
+        checkSchoolsNotPopulated(p);
+
+        // Day 3 - holiday
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(t, new DailyStats(t));
+            t = t.advance();
+        }
+        checkSchoolsPopulated(p);
+
+        // Day 4 - open again
+        for (int i = 0; i < 24; i++) {
+            p.timeStep(t, new DailyStats(t));
+            t = t.advance();
+        }
+        checkSchoolsNotPopulated(p);
     }
 
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -5,7 +5,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.householdtypes.SmallFamily;
@@ -14,7 +14,6 @@ import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Probability;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PersonTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PersonTest.java
@@ -1,7 +1,7 @@
 package uk.co.ramp.covid.simulation.population;
 
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.Time;
+import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import static org.junit.Assert.*;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -1,9 +1,7 @@
 package uk.co.ramp.covid.simulation.population;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.Time;
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.*;

--- a/src/test/resources/default_params.json
+++ b/src/test/resources/default_params.json
@@ -178,7 +178,13 @@
             "pOfficeKey":0.5,
             "pShopKey":0.5,
             "pLeaveShop": 0.5,
-            "pLeaveRestaurant": 0.4
+            "pLeaveRestaurant": 0.4,
+            "schoolHolidays": [
+                {
+                    "start": 28,
+                    "end": 32
+                }
+            ]
         },
         "infantProperties":{
             "pAttendsNursery":0.12


### PR DESCRIPTION
This PR implements https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/447 by adding school holidays (with the option of holidays more generally).

There's a possibility we should move Holidays into "OpeningTimes" - probably as part https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/410, i.e. set the opening times/holidays together,  but for now let's leave it in CommunalPlace since it's only used for schools.

Date ranges are non-inclusive, so { start : 2, end :3 } is a 1 day closure (reopenning *on* 3), not closed on days 2 *and* 3. Let me know if you want that changed @paulbessell.

You may specify a list of holidays - allowing summer holidays, October week etc, to all be captured.

Looks like a lot of file changes, but most of them are moving Time/DateRange into the util package.