### PR TITLE
Tweaks to how we handle lockdown/key places

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownController.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownController.java
@@ -58,15 +58,21 @@ public class LockdownController {
         }
     }
     
-    private void increaseSocialDistancing() {
+    private void lockdownPlaces() {
         for (CommunalPlace cPlace : population.getPlaces().getAllPlaces()) {
-            cPlace.adjustSDist(socialDist);
+            cPlace.enterLockdown(socialDist);
+        }
+    }
+
+    private void unLockdownPlaces() {
+        for (CommunalPlace cPlace : population.getPlaces().getAllPlaces()) {
+            cPlace.exitLockdown();
         }
     }
 
     private void enterLockdown(Time t) {
         inLockdown = true;
-        increaseSocialDistancing();
+        lockdownPlaces();
         furloughStaff();
     }
 
@@ -85,6 +91,7 @@ public class LockdownController {
         if (schoolLockdown) {
             schoolExemption();
         } else {
+            unLockdownPlaces();
             unFurloughStaff();
             inLockdown = false;
         }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CareHome.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CareHome.java
@@ -24,7 +24,10 @@ public class CareHome extends CommunalPlace implements Home {
         shifts.put(new Shifts(14,22, 0, 1, 2));
         shifts.put(new Shifts(6,14, 3, 4, 5, 6));
         shifts.put(new Shifts(14,22, 3, 4, 5, 6));
+    }
 
+    @Override
+    protected void setKey() {
         keyPremises = true;
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CareHome.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CareHome.java
@@ -24,6 +24,8 @@ public class CareHome extends CommunalPlace implements Home {
         shifts.put(new Shifts(14,22, 0, 1, 2));
         shifts.put(new Shifts(6,14, 3, 4, 5, 6));
         shifts.put(new Shifts(14,22, 3, 4, 5, 6));
+
+        keyPremises = true;
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -45,9 +45,11 @@ public abstract class CommunalPlace extends Place {
         super();
         this.rng = RNG.get();
         this.times = new OpeningTimes(8,17,1,5, OpeningTimes.getAllDays());
-        this.keyPremises = false;
         setHolidays();
+        setKey();
     }
+    
+    protected abstract void setKey();
 
     public void overrideKeyPremises(boolean key) {
         keyPremises = key;

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -27,7 +27,7 @@ public abstract class CommunalPlace extends Place {
     protected Size size;
     protected OpeningTimes times;
     protected boolean keyPremises;
-    protected Probability keyProb;
+    private boolean closed = false;
 
     protected int nStaff = 0;
 
@@ -49,12 +49,8 @@ public abstract class CommunalPlace extends Place {
         setHolidays();
     }
 
-    public void overrideKeyPremises(boolean overR) {
-        this.keyPremises = overR;
-    }
-
-    public void adjustSDist(double sVal) {
-        this.sDistance = sVal;
+    public void overrideKeyPremises(boolean key) {
+        keyPremises = key;
     }
 
     public Size getSize() {
@@ -72,7 +68,7 @@ public abstract class CommunalPlace extends Place {
                 continue;
             }
 
-            if (p.worksNextHour(this, t, lockdown)) {
+            if (p.worksNextHour(this, t)) {
                 p.stayInPlace(this);
             } else {
                 p.returnHome(this);
@@ -147,6 +143,10 @@ public abstract class CommunalPlace extends Place {
     }
 
     public boolean isOpen(Time t) {
+        if (closed) {
+            return false;
+        }
+
         for (DateRange holiday : holidays) {
             if (holiday.inRange(t)) {
                 return false;
@@ -186,5 +186,17 @@ public abstract class CommunalPlace extends Place {
     
     public void setHolidays() {
         holidays = new ArrayList<>();
+    }
+    
+    public void enterLockdown(double sDist) {
+        sDistance = sDist;
+        if (!keyPremises) {
+            closed = true;
+        }
+    }
+    
+    public void exitLockdown() {
+        sDistance = 1.0;
+        closed = false;
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
@@ -11,8 +11,12 @@ public class ConstructionSite extends CommunalPlace {
     public ConstructionSite(Size s) {
         super(s);
         transAdjustment = PopulationParameters.get().buildingProperties.constructionSiteTransmissionConstant;
-        keyPremises = PopulationParameters.get().buildingProperties.pConstructionSiteKey.sample();
         times = OpeningTimes.nineFiveWeekdays();
+    }
+
+    @Override
+    protected void setKey() {
+        keyPremises = PopulationParameters.get().buildingProperties.pConstructionSiteKey.sample();
     }
 
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/ConstructionSite.java
@@ -11,8 +11,7 @@ public class ConstructionSite extends CommunalPlace {
     public ConstructionSite(Size s) {
         super(s);
         transAdjustment = PopulationParameters.get().buildingProperties.constructionSiteTransmissionConstant;
-        keyProb = PopulationParameters.get().buildingProperties.pConstructionSiteKey;
-        if (keyProb.sample()) keyPremises = true;
+        keyPremises = PopulationParameters.get().buildingProperties.pConstructionSiteKey.sample();
         times = OpeningTimes.nineFiveWeekdays();
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -15,10 +15,10 @@ public class Hospital extends CommunalPlace {
 
     public Hospital(Size s) {
         super(s);
+        // TODO: Adjustment or constant?
         transAdjustment = PopulationParameters.get().buildingProperties.hospitalTransmissionConstant;
-        keyProb = PopulationParameters.get().buildingProperties.pHospitalKey;
         times = OpeningTimes.twentyfourSeven();
-        if (keyProb.sample()) keyPremises = true;
+        keyPremises =  PopulationParameters.get().buildingProperties.pHospitalKey.sample();
         allocateShifts();
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -18,8 +18,12 @@ public class Hospital extends CommunalPlace {
         // TODO: Adjustment or constant?
         transAdjustment = PopulationParameters.get().buildingProperties.hospitalTransmissionConstant;
         times = OpeningTimes.twentyfourSeven();
-        keyPremises =  PopulationParameters.get().buildingProperties.pHospitalKey.sample();
         allocateShifts();
+    }
+
+    @Override
+    protected void setKey() {
+        keyPremises =  PopulationParameters.get().buildingProperties.pHospitalKey.sample();
     }
 
     private void allocateShifts() {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -193,7 +193,7 @@ public abstract class Household extends Place implements Home {
         if (!isIsolating() && getNumInhabitants() > 0) {
             // Ordering here implies work takes highest priority, then shopping trips have higher priority
             // than neighbour and restaurant trips
-            moveShift(t, lockdown);
+            moveShift(t);
 
             // Shops are only open 8-22
             if (t.getHour() + 1 >= 8 && t.getHour() + 1 < 22) {
@@ -309,14 +309,14 @@ public abstract class Household extends Place implements Home {
         familyTrip(t, places::getRandomRestaurant, visitProb);
     }
 
-    private void moveShift(Time t, boolean lockdown) {
+    private void moveShift(Time t) {
         for (Person p : getPeople()) {
             if (p.hasMoved()) {
                 continue;
             }
 
             if (isInhabitant(p) && !p.getQuarantine()
-                    && p.worksNextHour(p.getPrimaryCommunalPlace(), t, lockdown)) {
+                    && p.worksNextHour(p.getPrimaryCommunalPlace(), t)) {
                 p.moveToPrimaryPlace(this);
             }
         }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Nursery.java
@@ -15,6 +15,11 @@ public class Nursery extends CommunalPlace {
     }
 
     @Override
+    protected void setKey() {
+        keyPremises = false;
+    }
+
+    @Override
     public void reportInfection(Time t, Person p, DailyStats s) {
         if (p.isWorking(this, t) && p.getAge() >= 18) {
             s.incInfectionsNurseryWorker();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -11,8 +11,12 @@ public class Office extends CommunalPlace {
     public Office(Size s)  {
         super(s);
         transAdjustment = PopulationParameters.get().buildingProperties.officeTransmissionConstant;
-        keyPremises = PopulationParameters.get().buildingProperties.pOfficeKey.sample();
         times = OpeningTimes.nineFiveWeekdays();
+    }
+
+    @Override
+    protected void setKey() {
+        keyPremises = PopulationParameters.get().buildingProperties.pOfficeKey.sample();
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Office.java
@@ -11,8 +11,7 @@ public class Office extends CommunalPlace {
     public Office(Size s)  {
         super(s);
         transAdjustment = PopulationParameters.get().buildingProperties.officeTransmissionConstant;
-        keyProb = PopulationParameters.get().buildingProperties.pOfficeKey;
-        if (keyProb.sample()) keyPremises = true;
+        keyPremises = PopulationParameters.get().buildingProperties.pOfficeKey.sample();
         times = OpeningTimes.nineFiveWeekdays();
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -160,7 +160,7 @@ public abstract class Place {
             if (p != q
                     && q.getHome() == p.getHome()
                     && !p.hasMoved()
-                    && !q.worksNextHour(place, t, false)) {
+                    && !q.worksNextHour(place, t)) {
                 q.returnHome(this);
             }
         }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -16,8 +16,12 @@ public class Restaurant extends CommunalPlace {
     public Restaurant(Size s) {
         super(s);
         transAdjustment = PopulationParameters.get().buildingProperties.restaurantTransmissionConstant;
-        keyPremises = false;
         setOpeningHours();
+    }
+
+    @Override
+    protected void setKey() {
+        keyPremises = false;
     }
 
     private void setOpeningHours() {

--- a/src/main/java/uk/co/ramp/covid/simulation/place/School.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/School.java
@@ -17,6 +17,11 @@ public class School extends CommunalPlace {
     }
 
     @Override
+    protected void setKey() {
+        keyPremises = false;
+    }
+
+    @Override
     public void reportInfection(Time t, Person p, DailyStats s) {
         if (p.isWorking(this, t) && p.getAge() >= 18) {
             s.incInfectionsSchoolWorker();

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -15,8 +15,7 @@ public class Shop extends CommunalPlace {
     public Shop(Size s) {
         super(s);
         transAdjustment = PopulationParameters.get().buildingProperties.shopTransmissionConstant;
-        keyProb = PopulationParameters.get().buildingProperties.pShopKey;
-        if (keyProb.sample()) keyPremises = true;
+        keyPremises = PopulationParameters.get().buildingProperties.pShopKey.sample();
         setOpeningHours();
     }
     

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -15,10 +15,14 @@ public class Shop extends CommunalPlace {
     public Shop(Size s) {
         super(s);
         transAdjustment = PopulationParameters.get().buildingProperties.shopTransmissionConstant;
-        keyPremises = PopulationParameters.get().buildingProperties.pShopKey.sample();
         setOpeningHours();
     }
-    
+
+    @Override
+    protected void setKey() {
+        keyPremises = PopulationParameters.get().buildingProperties.pShopKey.sample();
+    }
+
     private void setOpeningHours() {
         shifts = new RoundRobinAllocator<>();
         if (size == Size.SMALL) {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -254,16 +254,10 @@ public abstract class Person {
     }
 
 
-    public boolean worksNextHour(CommunalPlace communalPlace, Time t, boolean lockdown) {
+    public boolean worksNextHour(CommunalPlace communalPlace, Time t) {
         if (primaryPlace == null || shifts == null || primaryPlace != communalPlace
                 || !communalPlace.isOpenNextHour(t)) {
             return false;
-        }
-
-        if (lockdown) {
-            if (!communalPlace.isKeyPremises()) {
-                return false;
-            }
         }
 
         // Handle day crossovers


### PR DESCRIPTION
Being closed is now a property of the place (rather than passing lockdown as a parameter when the person decides if they should work).

We also force a decision on key status when places are constructed (for example, CareHomes managed to not set themselves as key!). This is done through abstract methods to avoid needing to pass in key status as a constructor parameter (since these mostly come from the parameters file anyway and don't tend to change per building type). 