### PR TITLE
Fix Stuck Infections

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -228,7 +228,7 @@ public abstract class Person {
     public abstract boolean avoidsPhase2(double testP);
 
     protected boolean isWorking(CommunalPlace communalPlace, Time t, boolean furloughed) {
-        if (primaryPlace == null || shifts == null || furloughed) {
+        if (primaryPlace == null || shifts == null || furloughed || isHospitalised) {
             return false;
         }
 

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -70,11 +70,6 @@ public class HospitalTest extends SimulationTest {
         CovidParameters.get().diseaseParameters.adultProgressionPhase2 = 100.0;
         CovidParameters.get().diseaseParameters.mortalityRate = 0.0;
 
-        // TODO: Infection get's stuck with seed = 0; seems related to the people getting stuck in phase2 issue,
-        //  not isolation/quarantine so will be fixed later. Related to RNG since it works if we don't sample pQuarantines
-        //  at construction time.
-        RNG.seed(42);
-
         Population pop = PopulationGenerator.genValidPopulation(populationSize);
         pop.seedVirus(nInfections);
 


### PR DESCRIPTION
This fixes stuck infections. In particular for the isolation refactoring test case, but I hope this also fixes the issue with many people getting stuck in phase 2 (please let me know if this is the case @paulbessell since I'm no 100% sure how to reproduce your case).

Issue was that that patients in a COVID hospital could get confused with workers (if they also work there), and this caused them to get lost.

Isolation refactoring branch should be merged first.