### PR TITLE
Record numbers in hospital/sent to hospital with COVID

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -278,6 +278,7 @@ public class Model {
                               "ICs_V","IHos_V","INur_V","IOff_V","IRes_V","ISch_V","ISho_V","IHome_V",
                               "IAdu","IPen","IChi","IInf",
                               "DAdul","DPen","DChi","DInf","DHome", "DHospital", "DCareHome", "DAdditional",
+                              "NumHospital", "HospitalisedToday",
                               "SecInfections", "GenerationTime" };
         try {
             FileWriter out = new FileWriter(outF.toFile());

--- a/src/main/java/uk/co/ramp/covid/simulation/output/DailyStats.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/DailyStats.java
@@ -65,6 +65,10 @@ public class DailyStats {
     private Double secInfections = null;
     private Double generationTime = null;
 
+    // Hospitalisation Stats
+    private int inHospital = 0;
+    private int newlyHospitalised = 0;
+
     public DailyStats(Time t) {
         this.day = t.getAbsDay();
     }
@@ -78,6 +82,10 @@ public class DailyStats {
             case PHASE2: phase2++; break;
             case RECOVERED: recovered++; break;
             case DEAD: dead++; break;
+        }
+        
+        if (p.isHospitalised()) {
+            inHospital++;
         }
     }
 
@@ -126,8 +134,9 @@ public class DailyStats {
     public int getShopInfectionsVisitor() { return shopInfectionsVisitor; }
 
     public void log(){
-        LOGGER.info("Day = {} Healthy = {} Latent = {} Asymptomatic = {} Phase 1 = {} Phase 2 = {} Dead = {} Recovered = {}",
-                day, healthy, exposed, asymptomatic,phase1, phase2, dead, recovered);
+        LOGGER.info("Day = {} Healthy = {} Latent = {} Asymptomatic = {} Phase 1 = {} " +
+                        "Phase 2 = {} Hospitalised = {} Dead = {} Recovered = {}",
+                day, healthy, exposed, asymptomatic,phase1, phase2, inHospital, dead, recovered);
     }
 
     public void appendCSV(CSVPrinter csv, int iter) throws IOException {
@@ -140,6 +149,7 @@ public class DailyStats {
                 officeInfectionsVisitor, restaurantInfectionsVisitor, schoolInfectionsVisitor, shopInfectionsVisitor,
                 homeInfectionsVisitor, adultInfected, pensionerInfected, childInfected, infantInfected, adultDeaths,
                 pensionerDeaths, childDeaths, infantDeaths, homeDeaths, hospitalDeaths, careHomeDeaths, additionalDeaths,
+                inHospital, newlyHospitalised,
                 secInfections, generationTime);
     }
 
@@ -398,4 +408,10 @@ public class DailyStats {
     public void incAdditionalDeaths() { additionalDeaths++; }
     
     public int getAdditionalDeaths() { return additionalDeaths; }
+    
+    public void incHospitalised() { newlyHospitalised++; }
+
+    public int getNewlyHospitalised() { return newlyHospitalised; }
+
+    public int getNumInHospital() { return inHospital; }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CareHome.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CareHome.java
@@ -52,8 +52,8 @@ public class CareHome extends CommunalPlace implements Home {
     }
 
     @Override
-    public void determineMovement(Time t, boolean lockdown, Places places) {
-        movePhase2(t, places, Person::isInCare);
+    public void determineMovement(Time t, DailyStats s, boolean lockdown, Places places) {
+        movePhase2(t, s, places, Person::isInCare);
         moveShifts(t, lockdown, Person::isInCare);
         remainInPlace();
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/CommunalPlace.java
@@ -5,6 +5,7 @@
 package uk.co.ramp.covid.simulation.place;
 
 import org.apache.commons.math3.random.RandomDataGenerator;
+import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.util.DateRange;
 import uk.co.ramp.covid.simulation.population.CStatus;
@@ -83,7 +84,7 @@ public abstract class CommunalPlace extends Place {
     }
 
     /** Moves Phase2 people to either hospital or back home */
-    public void movePhase2(Time t, Places places, Function<Person,Boolean> filter) {
+    public void movePhase2(Time t, DailyStats s, Places places, Function<Person,Boolean> filter) {
         for (Person p : getPeople()) {
             if (p.hasMoved() || filter.apply(p)) {
                 continue;
@@ -92,7 +93,7 @@ public abstract class CommunalPlace extends Place {
             if (p.cStatus() != null && p.cStatus() == CStatus.PHASE2) {
                 if (p.goesToHosptialInPhase2()) {
                     CovidHospital h = places.getRandomCovidHospital();
-                    p.hospitalise();
+                    p.hospitalise(s);
                     p.moveTo(this, h);
                 } else {
                     p.returnHome(this);
@@ -132,8 +133,8 @@ public abstract class CommunalPlace extends Place {
     }
 
 
-    public void movePhase2(Time t, Places places) {
-        movePhase2(t, places, p -> false);
+    public void movePhase2(Time t, DailyStats s, Places places) {
+        movePhase2(t, s, places, p -> false);
     }
     
     public boolean isVisitorOpenNextHour(Time t) {
@@ -169,8 +170,8 @@ public abstract class CommunalPlace extends Place {
     }
 
     @Override
-    public void determineMovement(Time t, boolean lockdown, Places places) {
-        movePhase2(t, places);
+    public void determineMovement(Time t, DailyStats s, boolean lockdown, Places places) {
+        movePhase2(t, s, places);
         moveShifts(t, lockdown);
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Hospital.java
@@ -69,8 +69,8 @@ public class Hospital extends CommunalPlace {
     }
     
     @Override
-    public void determineMovement(Time t, boolean lockdown, Places places) {
-        movePhase2(t, places, Person::isHospitalised);
+    public void determineMovement(Time t, DailyStats s, boolean lockdown, Places places) {
+        movePhase2(t, s, places, Person::isHospitalised);
         moveShifts(t, lockdown, Person::isHospitalised);
         movePatients(t);
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -167,7 +167,7 @@ public abstract class Household extends Place implements Home {
         }
     }
     
-    public void goToHospital(Time t, Places places) {
+    public void goToHospital(Time t, DailyStats s, Places places) {
         for (Person p : getPeople() ) {
             if (p.hasMoved()) {
                 continue;
@@ -175,7 +175,7 @@ public abstract class Household extends Place implements Home {
 
             if (p.cStatus() != null && p.cStatus() == CStatus.PHASE2) {
                 if (p.goesToHosptialInPhase2()) {
-                    p.hospitalise();
+                    p.hospitalise(s);
                     CovidHospital h = places.getRandomCovidHospital();
                     p.moveTo(this, h);
                 } else if (isVisitor(p)) {
@@ -187,8 +187,8 @@ public abstract class Household extends Place implements Home {
     }
 
     @Override
-    public void determineMovement(Time t, boolean lockdown, Places places) {
-        goToHospital(t, places);
+    public void determineMovement(Time t, DailyStats s, boolean lockdown, Places places) {
+        goToHospital(t, s, places);
 
         if (!isIsolating() && getNumInhabitants() > 0) {
             // Ordering here implies work takes highest priority, then shopping trips have higher priority

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -184,5 +184,5 @@ public abstract class Place {
 
 
     /** Handles movement between people in this place */
-    public abstract void determineMovement(Time t, boolean lockdown, Places places);
+    public abstract void determineMovement(Time t, DailyStats s, boolean lockdown, Places places);
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Restaurant.java
@@ -62,8 +62,8 @@ public class Restaurant extends CommunalPlace {
     }
 
     @Override
-    public void determineMovement(Time t, boolean lockdown, Places places) {
-        movePhase2(t, places);
+    public void determineMovement(Time t, DailyStats s, boolean lockdown, Places places) {
+        movePhase2(t, s, places);
         moveShifts(t, lockdown);
         moveVisitors(t, PopulationParameters.get().buildingProperties.pLeaveRestaurant);
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Shop.java
@@ -54,8 +54,8 @@ public class Shop extends CommunalPlace {
     }
 
     @Override
-    public void determineMovement(Time t, boolean lockdown, Places places) {
-        movePhase2(t, places);
+    public void determineMovement(Time t, DailyStats s, boolean lockdown, Places places) {
+        movePhase2(t, s, places);
         moveShifts(t, lockdown);
         moveVisitors(t, PopulationParameters.get().buildingProperties.pLeaveShop);
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -145,8 +145,9 @@ public abstract class Person {
         return isInCare;
     }
 
-    public void hospitalise() {
+    public void hospitalise(DailyStats s) {
         isHospitalised = true;
+        s.incHospitalised();
     }
 
     public boolean goesToHosptialInPhase2() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -322,12 +322,12 @@ public class Population {
         for (Household h : households) {
             h.doTesting(t);
             h.doInfect(t, dStats);
-            h.determineMovement(t, lockdownController.inLockdown(t), getPlaces());
+            h.determineMovement(t, dStats, lockdownController.inLockdown(t), getPlaces());
         }
 
         for (Place p : places.getAllPlaces()) {
             p.doInfect(t, dStats);
-            p.determineMovement(t, lockdownController.inLockdown(t), getPlaces());
+            p.determineMovement(t, dStats, lockdownController.inLockdown(t), getPlaces());
         }
         
         for (Household h : households) {

--- a/src/test/java/uk/co/ramp/covid/simulation/output/DailyStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/DailyStatsTest.java
@@ -63,6 +63,11 @@ public class DailyStatsTest extends SimulationTest {
         int childDeaths = 0;
         int infantDeaths = 0;
 
+        // Hospitalisation Stats
+        int hospitalised = 0;
+        int newlyHospitalised = 0;
+        int totalPhase2 = 0;
+
         nDays = 100;
         Model run1 = new Model()
                 .setPopulationSize(population)
@@ -122,6 +127,12 @@ public class DailyStatsTest extends SimulationTest {
             shopInfectionsVisitor += stats.get(0).get(i).getShopInfectionsVisitor();
             careHomeInfectionsWorker += stats.get(0).get(i).getCareHomeInfectionsWorker();
             careHomeInfectionsResident += stats.get(0).get(i).getCareHomeInfectionsResident();
+
+            // Hospitalised will double count people (since you might in in hospital multiple days),
+            // so we need to account for this in the test cases
+            hospitalised += stats.get(0).get(i).getNumInHospital();
+            newlyHospitalised += stats.get(0).get(i).getNewlyHospitalised();
+            totalPhase2 +=  stats.get(0).get(i).getPhase2();
         }
         int expDeaths = adultDeaths + childDeaths + pensionerDeaths + infantDeaths;
         int expInfected = adultInfected + childInfected + pensionerInfected + infantInfected + seedInfections;
@@ -137,6 +148,11 @@ public class DailyStatsTest extends SimulationTest {
         assertEquals("Inconsistent number of deaths", expDeaths, stats.get(0).get(nDays - 1).getDead());
         assertEquals("Inconsistent number of infected", expInfected, dailyInfected);
         assertEquals("Inconsistent number of place infections", expPlaceInfections, dailyInfected);
+        
+        assertNotEquals("Some people are hospitalised", hospitalised);
+        assertNotEquals("Some people are hospitalised", newlyHospitalised);
+        assertTrue("Hospitalised should be > newlyHospitalised", newlyHospitalised > 0);
+        assertTrue("Hospitalised <= phase2", newlyHospitalised <= totalPhase2);
     }
 
     @Test

--- a/src/test/java/uk/co/ramp/covid/simulation/place/CareHomeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/CareHomeTest.java
@@ -1,6 +1,7 @@
 package uk.co.ramp.covid.simulation.place;
 
 import org.junit.Test;
+import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
@@ -124,7 +125,7 @@ public class CareHomeTest extends SimulationTest {
         CareHome ch = new CareHome(CommunalPlace.Size.MED);
         ch.addPerson(new Pensioner(80, FEMALE));
         ch.addPerson(new Pensioner(85, MALE));
-        ch.determineMovement(time,  false, null);
+        ch.determineMovement(time, new DailyStats(time), false, null);
         ch.commitMovement();
         int expPeople = 2;
         assertEquals("People Unexpectedly left the care home", expPeople, ch.getNumPeople());

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
@@ -112,7 +112,7 @@ public class ConstructionSiteTest extends SimulationTest {
         cs.addPerson(new Adult(30, FEMALE));
         cs.addPerson(new Adult(35, MALE));
         int time = cs.times.getClose() - 1;
-        cs.determineMovement(new Time(time),  false, null);
+        cs.determineMovement(new Time(time), new DailyStats(new Time(time)), false, null);
         cs.commitMovement();
         int expPeople = 0;
         assertEquals("Unexpected people left on construction site", expPeople, cs.getNumPeople());

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -230,7 +230,7 @@ public class HospitalTest extends SimulationTest {
         adult2.setHome(h);
         hospital.addPerson(adult1);
         hospital.addPerson(adult2);
-        hospital.determineMovement(new Time(0),  false, null);
+        hospital.determineMovement(new Time(0), new DailyStats(new Time(0)), false, null);
         hospital.commitMovement();
         int expPeople = 0;
         assertEquals("Unexpected people left in hospital", expPeople, hospital.getNumPeople());

--- a/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
@@ -71,7 +71,7 @@ public class NurseryTest extends SimulationTest {
         nursery.addPerson(new Infant(1, FEMALE));
         nursery.addPerson(new Infant(2, MALE));
         int time = nursery.times.getClose() - 1;
-        nursery.determineMovement(new Time(time),  false, null);
+        nursery.determineMovement(new Time(time), new DailyStats(new Time(time)), false, null);
         nursery.commitMovement();
         int expPeople = 0;
         assertEquals("Unexpected infants left in nursery", expPeople, nursery.getNumPeople());

--- a/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
@@ -72,7 +72,7 @@ public class OfficeTest extends SimulationTest {
         office.addPerson(new Adult(30, FEMALE));
         office.addPerson(new Adult(35, MALE));
         int time = office.times.getClose() - 1;
-        office.determineMovement(new Time(time),  false, null);
+        office.determineMovement(new Time(time), new DailyStats(new Time(time)), false, null);
         office.commitMovement();
         int expPeople = 0;
         assertEquals("Unexpected people left in office", expPeople, office.getNumPeople());

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -50,7 +50,7 @@ public class RestaurantTest extends SimulationTest {
     public void testSendHome() {
         PopulationParameters.get().buildingProperties.pLeaveRestaurant = new Probability(1.0);
         int time = restaurant.times.getClose() - 1;
-        restaurant.determineMovement(new Time(time), false, null);
+        restaurant.determineMovement(new Time(time), new DailyStats(new Time(time)), false, null);
         restaurant.commitMovement();
         int expPeople = 0;
         assertEquals("Unexpected people left in restaurant", expPeople, restaurant.getNumPeople());

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -84,7 +84,7 @@ public class SchoolTest extends SimulationTest {
         school.addPerson(new Child(10, FEMALE));
         school.addPerson(new Child(5, MALE));
         int time = school.times.getClose() - 1;
-        school.determineMovement(new Time(time),  false, null);
+        school.determineMovement(new Time(time), new DailyStats(new Time(time)), false, null);
         school.commitMovement();
         int expPeople = 0;
         assertEquals("Unexpected children left in school", expPeople, school.getNumPeople());

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -49,7 +49,7 @@ public class ShopTest extends SimulationTest {
     public void testSendHome() {
         PopulationParameters.get().buildingProperties.pLeaveShop = new Probability(1.0);
         int time = shop.times.getClose() - 1;
-        shop.determineMovement(new Time(time),  false, null);
+        shop.determineMovement(new Time(time), new DailyStats(new Time(time)), false, null);
         shop.commitMovement();
         int expPeople = 0;
         assertEquals("Unexpected people left in shop", expPeople, shop.getNumPeople());


### PR DESCRIPTION
Implements https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/482

Provides the number in hospital on a particular day (Note this is the number that *finished* the day in hospital) and the number of people sent to hospital on a given day.

Most changes are in the API to allow DailyStats to be passed to movement functions.