### PR TITLE
Fix furloughed staff going to work

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownController.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownController.java
@@ -54,7 +54,7 @@ public class LockdownController {
 
     private void unFurloughStaff() {
         for (Person p : population.getAllPeople()) {
-            p.furlough();
+            p.unFurlough();
         }
     }
     

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
@@ -16,7 +16,7 @@ public class Adult extends Person {
     Professions profession;
     
     private boolean willFurlough = false;
-    private boolean furloughed = false;
+
 
     public Adult(int age, Sex sex) {
         super(age, sex);
@@ -94,22 +94,10 @@ public class Adult extends Person {
     }
 
     @Override
-    public boolean isWorking(CommunalPlace communalPlace, Time t) {
-       return isWorking(communalPlace, t, isFurloughed());
-    }
-    
-    public boolean isFurloughed() { return furloughed; }
-    
     public void furlough() {
         if (willFurlough) {
             furloughed = true;
         }
     }
-    
-    public void unFurlough() {
-        furloughed = false;
-    }
-
-
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -47,6 +47,7 @@ public abstract class Person {
     private final int personId;
 
     private boolean isInCare = false;
+    protected boolean furloughed = false;
     
     private boolean moved = false;
 
@@ -242,8 +243,8 @@ public abstract class Person {
 
     public abstract boolean avoidsPhase2(double testP);
 
-    protected boolean isWorking(CommunalPlace communalPlace, Time t, boolean furloughed) {
-        if (primaryPlace == null || shifts == null || furloughed || isHospitalised) {
+    public boolean isWorking(CommunalPlace communalPlace, Time t) {
+        if (primaryPlace == null || shifts == null || isFurloughed() || isHospitalised) {
             return false;
         }
 
@@ -258,34 +259,9 @@ public abstract class Person {
                 && t.getHour() >= start
                 && t.getHour() < end;
     }
-
-    public boolean isWorking(CommunalPlace communalPlace, Time t) {
-        return isWorking(communalPlace, t, false);
-    }
-
-
+    
     public boolean worksNextHour(CommunalPlace communalPlace, Time t) {
-        if (primaryPlace == null || shifts == null || primaryPlace != communalPlace
-                || !communalPlace.isOpenNextHour(t)) {
-            return false;
-        }
-
-        // Handle day crossovers
-        int day = t.getDay();
-        int nextHour = 0;
-        if (t.getHour() + 1 == 24) {
-            day = (day + 1) % 7;
-        } else {
-            nextHour = t.getHour() + 1;
-        }
-
-        int start = shifts.getShift(day).getStart();
-        int end = shifts.getShift(day).getEnd();
-        if (end < start) {
-            end += 24;
-        }
-
-        return nextHour >= start && nextHour < end;
+        return isWorking(communalPlace, t.advance());
     }
 
     public void moveToPrimaryPlace(Place from) {
@@ -358,4 +334,9 @@ public abstract class Person {
     protected abstract double getInfectionSeedRate();
     
     public void furlough() {};
+
+    public boolean isFurloughed() { return furloughed; }
+    public void unFurlough() {
+        furloughed = false;
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -244,7 +244,9 @@ public abstract class Person {
     public abstract boolean avoidsPhase2(double testP);
 
     public boolean isWorking(CommunalPlace communalPlace, Time t) {
-        if (primaryPlace == null || shifts == null || isFurloughed() || isHospitalised) {
+        if (primaryPlace == null || shifts == null
+                || isFurloughed() || isHospitalised
+                || !communalPlace.isOpen(t)) {
             return false;
         }
 

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -93,7 +93,7 @@ public class ModelTest extends SimulationTest {
             adultDeaths = s.getAdultDeaths();
             pensionerDeaths += s.getPensionerDeaths();
             childDeaths += s.getChildDeaths();
-            totalDead += s.getHomeDeaths() + s.getHospitalDeaths() + s.getCareHomeDeaths();
+            totalDead += s.getHomeDeaths() + s.getHospitalDeaths() + s.getCareHomeDeaths() + s.getAdditionalDeaths();
         }
         
         List<DailyStats> s = stats.get(0);

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/LockdownTests.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/LockdownTests.java
@@ -1,0 +1,46 @@
+package uk.co.ramp.covid.simulation.integrationTests;
+
+import org.junit.Test;
+import uk.co.ramp.covid.simulation.output.DailyStats;
+import uk.co.ramp.covid.simulation.place.CommunalPlace;
+import uk.co.ramp.covid.simulation.place.Hospital;
+import uk.co.ramp.covid.simulation.place.Household;
+import uk.co.ramp.covid.simulation.place.Place;
+import uk.co.ramp.covid.simulation.population.Person;
+import uk.co.ramp.covid.simulation.population.Places;
+import uk.co.ramp.covid.simulation.population.Population;
+import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.testutil.SimulationTest;
+import uk.co.ramp.covid.simulation.util.Time;
+
+import static org.junit.Assert.assertFalse;
+
+public class LockdownTests extends SimulationTest  {
+
+    @Test
+    public void furloughedStaffDontGoToWork() {
+        final int simDays = 7;
+        final int populationSize = 20000;
+       
+        Population pop = PopulationGenerator.genValidPopulation(populationSize);
+
+        pop.setLockdown(2,4,0.5);
+
+        Time t = new Time(0);
+        
+        // First 2 days people go to work as usual
+        for (int i = 0; i < simDays; i++) {
+            pop.timeStep(t, new DailyStats(t));
+            t = t.advance();
+
+            // We only check hospitals since they 1. support furlough, 2. aren't visitable by staff members
+            for (Hospital plc : pop.getPlaces().getHospitals()) {
+                for (Person p : plc.getPeople()) {
+                    if (p.getPrimaryCommunalPlace() == plc && !p.isHospitalised()) {
+                        assertFalse(p.isFurloughed());
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes a bug where furloughed staff would still go to work.

Also tidied up the furlough handling while I was there since the function overloading was a bit messy.

Added a test case to hopefully stop this happening again.