### PR TITLE
Add git hash to log

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,15 @@ buildscript {
     }
 }
 
+group 'uk.co.ramp.covid.simulation'
+
 apply plugin: 'java'
 apply plugin: 'application'
 apply plugin: "org.sonarqube"
 apply plugin: 'jacoco'
 apply plugin: 'de.fuerstenau.buildconfig'
+apply plugin: 'eclipse'
+apply plugin: 'idea'
 
 ext {
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,9 @@ ext {
 
         def stdout = new ByteArrayOutputStream()
         exec {
-            commandLine 'git', 'rev-parse', 'HEAD'
+            // get git commit hash with -dirty appended for uncommitted changes
+            // (see https://stackoverflow.com/questions/21017300/git-command-to-get-head-sha1-with-dirty-suffix-if-workspace-is-not-clean)
+            commandLine 'git', 'describe', '--match=NeVeRmAtCh', '--always', '--abbrev=40', '--dirty'
             standardOutput = stdout
         }
         return stdout.toString().trim()

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ jacoco{
     version = '0.8.5'
 }
 
-version = '1.0.0'
+version = '0.1.0-SNAPSHOT'
 
 repositories {
     // Use jcenter for resolving dependencies.

--- a/src/main/java/uk/co/ramp/covid/simulation/RunModel.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/RunModel.java
@@ -23,6 +23,9 @@ public class RunModel {
             LOGGER.error("Expected parameters: <population_params.json> <model_params.json> <simulationID>");
             System.exit(-1);
         } else {
+            LOGGER.info(BuildConfig.NAME + " version " + BuildConfig.VERSION);
+            LOGGER.info("Git hash: " + BuildConfig.GitHash);
+
             String populationParamsFile = args[0];
             String modelParamsFile = args[1];
             int simulationID = Integer.parseInt(args[2]);


### PR DESCRIPTION
This is a PR on Bob's output_build_config branch, which adds the git hash to the log.  (There are 3 suggested changes, in 3 commits.)

Having done this, I'm now thinking it might be better to put this logging into Model.run(), instead of RunModel.main().

Eclipse seems to find the generated class file, with the 'eclipse' gradle plugin applied.  I'd appreciate it if someone else could confirm that IntelliJ IDEA is happy.