### PR TITLE
Retry population generation on error

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -14,7 +14,9 @@ import uk.co.ramp.covid.simulation.parameters.ParameterIO;
 import uk.co.ramp.covid.simulation.population.ImpossibleAllocationException;
 import uk.co.ramp.covid.simulation.population.ImpossibleWorkerDistributionException;
 import uk.co.ramp.covid.simulation.population.Population;
+import uk.co.ramp.covid.simulation.util.CannotGeneratePopulationException;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.util.RNG;
 
 import java.io.*;
@@ -198,8 +200,8 @@ public class Model {
             // seed (this can be accounted for when processing the output).
             Population p;
             try {
-                p = new Population(populationSize);
-            } catch (ImpossibleAllocationException | ImpossibleWorkerDistributionException e) {
+                p = PopulationGenerator.genValidPopulation(populationSize);
+            } catch (CannotGeneratePopulationException e) {
                 LOGGER.error(e);
                 break;
             }

--- a/src/main/java/uk/co/ramp/covid/simulation/util/CannotGeneratePopulationException.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/CannotGeneratePopulationException.java
@@ -1,0 +1,7 @@
+package uk.co.ramp.covid.simulation.util;
+
+public class CannotGeneratePopulationException extends RuntimeException {
+    CannotGeneratePopulationException() {
+        super("Could not generate a valid population");
+    }
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/util/PopulationGenerator.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/PopulationGenerator.java
@@ -1,4 +1,4 @@
-package uk.co.ramp.covid.simulation.testutil;
+package uk.co.ramp.covid.simulation.util;
 
 import uk.co.ramp.covid.simulation.population.ImpossibleAllocationException;
 import uk.co.ramp.covid.simulation.population.ImpossibleWorkerDistributionException;
@@ -8,15 +8,26 @@ public class PopulationGenerator {
     
     private static final int RETRIES = 20;
 
-    public static Population genValidPopulation(int populationsize) {
+    public static Population genValidPopulation(int populationsize) throws CannotGeneratePopulationException {
         Population p = null;
-        for (int i = 0; i < RETRIES; i++) {
+        for (int i = 0; i < RETRIES - 1; i++) {
             try {
                 p = new Population(populationsize);
+                break;
             } catch (ImpossibleAllocationException | ImpossibleWorkerDistributionException e2) {
                 continue;
             }
         }
+        
+        if (p == null) {
+            try {
+                p = new Population(populationsize);
+            } catch (ImpossibleAllocationException | ImpossibleWorkerDistributionException e2) {
+                throw new CannotGeneratePopulationException();
+            }
+
+        }
+        
         return p;
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/util/PopulationGenerator.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/PopulationGenerator.java
@@ -1,11 +1,13 @@
 package uk.co.ramp.covid.simulation.util;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.population.ImpossibleAllocationException;
 import uk.co.ramp.covid.simulation.population.ImpossibleWorkerDistributionException;
 import uk.co.ramp.covid.simulation.population.Population;
 
 public class PopulationGenerator {
-    
+    private static final Logger LOGGER = LogManager.getLogger(PopulationGenerator.class);
     private static final int RETRIES = 20;
 
     public static Population genValidPopulation(int populationsize) throws CannotGeneratePopulationException {
@@ -15,6 +17,7 @@ public class PopulationGenerator {
                 p = new Population(populationsize);
                 break;
             } catch (ImpossibleAllocationException | ImpossibleWorkerDistributionException e2) {
+                LOGGER.info("Could not generate valid population. Retrying");
                 continue;
             }
         }

--- a/src/test/java/uk/co/ramp/covid/simulation/covid/CovidTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/covid/CovidTest.java
@@ -3,7 +3,7 @@ package uk.co.ramp.covid.simulation.covid;
 import org.junit.After;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;

--- a/src/test/java/uk/co/ramp/covid/simulation/covid/InfectionLogTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/covid/InfectionLogTest.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.Population;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/LockdownTests.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/LockdownTests.java
@@ -2,14 +2,10 @@ package uk.co.ramp.covid.simulation.integrationTests;
 
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.place.CommunalPlace;
 import uk.co.ramp.covid.simulation.place.Hospital;
-import uk.co.ramp.covid.simulation.place.Household;
-import uk.co.ramp.covid.simulation.place.Place;
 import uk.co.ramp.covid.simulation.population.Person;
-import uk.co.ramp.covid.simulation.population.Places;
 import uk.co.ramp.covid.simulation.population.Population;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Time;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -11,7 +11,7 @@ import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.place.householdtypes.SingleAdult;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Probability;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/lockdown/LockdownControllerTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/lockdown/LockdownControllerTest.java
@@ -6,7 +6,7 @@ import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.place.Nursery;
 import uk.co.ramp.covid.simulation.place.School;
 import uk.co.ramp.covid.simulation.population.Population;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import static org.junit.Assert.*;

--- a/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
@@ -3,7 +3,7 @@ package uk.co.ramp.covid.simulation.output;
 import org.junit.Before;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.population.Population;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import static org.junit.Assert.*;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/CareHomeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/CareHomeTest.java
@@ -8,7 +8,7 @@ import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.Pensioner;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.Population;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Probability;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/place/CommunalPlaceTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/CommunalPlaceTest.java
@@ -6,7 +6,7 @@ import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.ImpossibleWorkerDistributionException;
 import uk.co.ramp.covid.simulation.population.Population;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
@@ -9,7 +9,7 @@ import uk.co.ramp.covid.simulation.Model;
 import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import java.util.ArrayList;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -1,17 +1,15 @@
 package uk.co.ramp.covid.simulation.place;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.util.RNG;
 import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Probability;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/NurseryTest.java
@@ -7,7 +7,7 @@ import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/OfficeTest.java
@@ -7,7 +7,7 @@ import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/RestaurantTest.java
@@ -9,7 +9,7 @@ import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.householdtypes.SmallFamily;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Probability;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/SchoolTest.java
@@ -7,7 +7,7 @@ import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import java.util.ArrayList;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ShopTest.java
@@ -9,7 +9,7 @@ import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.householdtypes.SmallFamily;
 import uk.co.ramp.covid.simulation.population.*;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Probability;
 

--- a/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/ChildTest.java
@@ -3,7 +3,7 @@ package uk.co.ramp.covid.simulation.population;
 import com.google.gson.JsonParseException;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.place.School;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/InfantTest.java
@@ -3,7 +3,7 @@ package uk.co.ramp.covid.simulation.population;
 import com.google.gson.JsonParseException;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import java.util.List;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PensionerTest.java
@@ -2,7 +2,7 @@ package uk.co.ramp.covid.simulation.population;
 
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.output.DailyStats;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 
 import java.util.List;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -6,7 +6,7 @@ import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.place.householdtypes.*;
-import uk.co.ramp.covid.simulation.testutil.PopulationGenerator;
+import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Probability;
 


### PR DESCRIPTION
Implements https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/506

Retry up to 20 times before we error.

Most of this code was already used in the PopulationGenerator test class, so I've just moved it to make it available to the model runner.