### PR TITLE
Fix unused imports and unused variable warnings

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -11,8 +11,6 @@ import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.output.network.ContactsWriter;
 import uk.co.ramp.covid.simulation.output.network.PeopleWriter;
 import uk.co.ramp.covid.simulation.parameters.ParameterIO;
-import uk.co.ramp.covid.simulation.population.ImpossibleAllocationException;
-import uk.co.ramp.covid.simulation.population.ImpossibleWorkerDistributionException;
 import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.util.CannotGeneratePopulationException;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/HospitalisationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/HospitalisationParameters.java
@@ -1,7 +1,5 @@
 package uk.co.ramp.covid.simulation.parameters;
 
-import uk.co.ramp.covid.simulation.util.Probability;
-
 public class HospitalisationParameters {
     public Double hospitalisationTransmissionReduction = null;
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -300,7 +300,6 @@ public abstract class Household extends Place implements Home {
                 // Do the visit
                 for (Person p : getPeople()) {
                     if (!p.hasMoved() && isInhabitant(p) && !p.isQuarantined()) {
-                        Household chosenNeighbour = n;
                         p.moveTo(this, n);
                     }
                 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Adult.java
@@ -1,6 +1,5 @@
 package uk.co.ramp.covid.simulation.population;
 
-import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
@@ -2,7 +2,6 @@ package uk.co.ramp.covid.simulation.population;
 
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.*;
-import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.ProbabilityDistribution;
 
 import java.util.ArrayList;

--- a/src/test/java/uk/co/ramp/covid/simulation/covid/CovidTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/covid/CovidTest.java
@@ -2,7 +2,6 @@ package uk.co.ramp.covid.simulation.covid;
 
 import org.junit.After;
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/LockdownTests.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/LockdownTests.java
@@ -1,7 +1,6 @@
 package uk.co.ramp.covid.simulation.integrationTests;
 
 import org.junit.Test;
-import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.place.Hospital;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.Population;

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -426,7 +426,6 @@ public class MovementTest extends SimulationTest {
     @Test
     public void neighboursShouldLeaveEmptyHouses() {
         final int simDays = 5;
-        Time t = new Time(0);
         p = PopulationGenerator.genValidPopulation(populationSize);
         p.seedVirus(nInfections);
 


### PR DESCRIPTION
This leaves two remaining warnings in Eclipse, where it was less obvious what to do with them:  Population.schoolExemption() is never called, and the value of Person.transmissionProb is not used.