### PR TITLE
Quicker Tests

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/output/RStats.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/RStats.java
@@ -45,8 +45,13 @@ public class RStats {
 
     /** Returns the mean R up to a given day */
     public Double getMeanRBefore(int absDay) {
-    	rflag = true;
-        return getMeanRGeneric(absDay, (a, b) -> a.compareTo(b) <= 0);
+        return getMeanRBetween(0, absDay);
+    }
+
+    /** Returns the mean R between two days */
+    public Double getMeanRBetween(int startDay, int endDay) {
+        rflag = true;
+        return getMeanRGeneric(endDay, (a, b) -> a.compareTo(startDay) > 0 && a.compareTo(b) <= 0);
     }
 
     /** Returns the mean generation time for a given day */

--- a/src/main/java/uk/co/ramp/covid/simulation/output/RStats.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/RStats.java
@@ -51,7 +51,7 @@ public class RStats {
     /** Returns the mean R between two days */
     public Double getMeanRBetween(int startDay, int endDay) {
         rflag = true;
-        return getMeanRGeneric(endDay, (a, b) -> a.compareTo(startDay) > 0 && a.compareTo(b) <= 0);
+        return getMeanRGeneric(endDay, (a, b) -> a.compareTo(startDay) >= 0 && a.compareTo(b) <= 0);
     }
 
     /** Returns the mean generation time for a given day */

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -8,7 +8,6 @@ import uk.co.ramp.covid.simulation.lockdown.FullLockdownEvent;
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
 import uk.co.ramp.covid.simulation.parameters.ParameterIO;
-import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Time;
 
 import java.io.IOException;
@@ -19,13 +18,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class ModelTest extends SimulationTest {
+public class ModelTest {
 
-    private static int population = 10000;
-    private static int nInfections = 150;
-    private static int nIter = 1;
-    private static int nDays = 60;
-    private static int RNG = 402;
+    private static final int population = 10000;
+    private static final int nInfections = 150;
+    private static final int nIter = 1;
+    private static final int nDays = 60;
+    private static final int testSeed = 402;
 
     // To avoid recomputes
     private static List<List<DailyStats>> cachedStats = null;
@@ -42,7 +41,7 @@ public class ModelTest extends SimulationTest {
                 .setExternalInfectionDays(0)
                 .setIters(nIter)
                 .setnDays(nDays)
-                .setRNGSeed(RNG)
+                .setRNGSeed(testSeed)
                 .setNoOutput();
 
         cachedStats = cachedRun.run(0);
@@ -115,7 +114,7 @@ public class ModelTest extends SimulationTest {
                 .setExternalInfectionDays(0)
                 .setIters(nIter)
                 .setnDays(nDays)
-                .setRNGSeed(RNG)
+                .setRNGSeed(testSeed)
                 .setNoOutput();
 
         List<List<DailyStats>> run2res = repeatRun.run(0);
@@ -165,7 +164,7 @@ public class ModelTest extends SimulationTest {
                 .setIters(nIter)
                 .setnDays(nDays)
                 .setNoOutput()
-                .setRNGSeed(RNG)
+                .setRNGSeed(testSeed)
                 .addLockdownEvent(new FullLockdownEvent(Time.timeFromDay(startLock), null,2.0));
 
         List<List<DailyStats>> stats2 = m2.run(0);

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -1,13 +1,13 @@
 package uk.co.ramp.covid.simulation;
 
-import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
 import uk.co.ramp.covid.simulation.lockdown.FullLockdownEvent;
 import uk.co.ramp.covid.simulation.output.DailyStats;
 import uk.co.ramp.covid.simulation.parameters.CovidParameters;
+import uk.co.ramp.covid.simulation.parameters.ParameterIO;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Time;
 
@@ -21,43 +21,43 @@ import static org.junit.Assert.assertTrue;
 
 public class ModelTest extends SimulationTest {
 
-    int population;
-    int nInfections;
-    int nIter;
-    int nDays;
-    int RNGSeed;
+    private static int population = 10000;
+    private static int nInfections = 150;
+    private static int nIter = 1;
+    private static int nDays = 60;
+    private static int RNG = 402;
 
-    @Before
-    public void setupParams() {
-        population = 10000;
-        nInfections = 10;
-        nIter = 1;
-        nDays = 60;
-        RNGSeed = 402;
-    }
+    // To avoid recomputes
+    private static List<List<DailyStats>> cachedStats = null;
 
-    @Test
-    public void testBaseLine() {
-        final int inf = nInfections * 5;
+    @BeforeClass
+    public static void singleRun() throws IOException {
+        ParameterIO.readParametersFromFile("parameters/example_population_params.json");
 
         double startTime = System.currentTimeMillis();
-        Model m = new Model()
+        
+        Model cachedRun = new Model()
                 .setPopulationSize(population)
-                .setnInitialInfections(inf)
+                .setnInitialInfections(nInfections)
                 .setExternalInfectionDays(0)
                 .setIters(nIter)
                 .setnDays(nDays)
-                .setRNGSeed(RNGSeed)
+                .setRNGSeed(RNG)
                 .setNoOutput();
 
-        List<List<DailyStats>> stats = m.run(0);
+        cachedStats = cachedRun.run(0);
 
-        int lastTotalInfected = inf;
         //Output model performance
         double runLength = (System.currentTimeMillis() - startTime)/1000.0;
         System.out.printf("Total run time (secs): %.3f\n", runLength);
         System.out.printf("Mean run time per day: %.3f\n", runLength/nDays);
+    }
 
+    @Test
+    public void testBaseLine() {
+        List<List<DailyStats>> stats = cachedStats;
+
+        int lastTotalInfected = nInfections;
         for (DailyStats s : stats.get(0)) {
             assertEquals(10000, s.getTotalPopulation());
 
@@ -73,7 +73,7 @@ public class ModelTest extends SimulationTest {
         }
 
         // Check all infections occurred somewhere
-        int totalDailyInfects = inf;
+        int totalDailyInfects = nInfections;
         int cummulativeI;
         for (DailyStats s : stats.get(0)) {
             cummulativeI = s.getTotalInfected() + s.getRecovered() + s.getDead();
@@ -109,32 +109,21 @@ public class ModelTest extends SimulationTest {
     @Test
     public void modelsWithSameRNGSeedGiveSameResult() {
 
-        Model run1 = new Model()
+        Model repeatRun = new Model()
                 .setPopulationSize(population)
                 .setnInitialInfections(nInfections)
                 .setExternalInfectionDays(0)
                 .setIters(nIter)
                 .setnDays(nDays)
-                .setRNGSeed(RNGSeed)
+                .setRNGSeed(RNG)
                 .setNoOutput();
 
-        List<List<DailyStats>> run1res = run1.run(0);
+        List<List<DailyStats>> run2res = repeatRun.run(0);
 
-        Model run2 = new Model()
-                .setPopulationSize(population)
-                .setnInitialInfections(nInfections)
-                .setExternalInfectionDays(0)
-                .setIters(nIter)
-                .setnDays(nDays)
-                .setRNGSeed(RNGSeed)
-                .setNoOutput();
+        assertEquals(cachedStats.size(), run2res.size());
+        assertEquals(cachedStats.get(0).size(), run2res.get(0).size());
 
-        List<List<DailyStats>> run2res = run2.run(0);
-
-        assertEquals(run1res.size(), run2res.size());
-        assertEquals(run1res.get(0).size(), run2res.get(0).size());
-
-        List<DailyStats> r1 = run1res.get(0);
+        List<DailyStats> r1 = cachedStats.get(0);
         List<DailyStats> r2 = run2res.get(0);
         for (int i = 0; i < r1.size(); i++) {
             assertEquals(r1.get(i), r2.get(i));
@@ -167,40 +156,27 @@ public class ModelTest extends SimulationTest {
     public void testLockdown() {
 
         int startLock = 30;
-        nInfections = 100;
-
-        //Run the model with no lockdown
-        Model m1 = new Model()
-                .setPopulationSize(population)
-                .setnInitialInfections(nInfections * 10)
-                .setExternalInfectionDays(0)
-                .setIters(nIter)
-                .setnDays(nDays)
-                .setRNGSeed(RNGSeed)
-                .setNoOutput();
-
-        List<List<DailyStats>> stats1 = m1.run(0);
 
         //Re-run the model with partial lockdown
         Model m2 = new Model()
                 .setPopulationSize(population)
-                .setnInitialInfections(nInfections * 10)
+                .setnInitialInfections(nInfections)
                 .setExternalInfectionDays(0)
                 .setIters(nIter)
                 .setnDays(nDays)
-                .setRNGSeed(RNGSeed)
                 .setNoOutput()
+                .setRNGSeed(RNG)
                 .addLockdownEvent(new FullLockdownEvent(Time.timeFromDay(startLock), null,2.0));
 
         List<List<DailyStats>> stats2 = m2.run(0);
 
         //Check that there are the same number of infections in both scenarios before lockdown starts
-        int inf1 = stats1.get(0).get(startLock - 1).getTotalInfected();
+        int inf1 = cachedStats.get(0).get(startLock - 1).getTotalInfected();
         int inf2 = stats2.get(0).get(startLock - 1).getTotalInfected();
         assertEquals("infection numbers don't match before lockdown", inf1, inf2);
 
         //Check that there are fewer infections in the lockdown scenario
-        inf1 = stats1.get(0).get(nDays - 1).getTotalInfected();
+        inf1 = cachedStats.get(0).get(nDays - 1).getTotalInfected();
         inf2 = stats2.get(0).get(nDays - 1).getTotalInfected();
         assertTrue("Unexpected more infections under lockdown." + inf1 + " > " + inf2, inf1 > inf2);
 

--- a/src/test/java/uk/co/ramp/covid/simulation/output/DailyStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/DailyStatsTest.java
@@ -163,10 +163,10 @@ public class DailyStatsTest extends SimulationTest {
 
     @Test
     public void testConsistentDeaths() {
-        int population = 20000;
+        int population = 10000;
         int nInfections = 300;
         int nIter = 1;
-        int nDays = 60;
+        int nDays = 50;
         int RNGSeed = 42;
         
         // Try to force at least 1 care home death for test purposes

--- a/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
@@ -19,7 +19,7 @@ public class RStatsTest extends SimulationTest {
 
     @Before
     public void setupParams() {
-        int populationSize = 50000;
+        int populationSize = 10000;
         pop = PopulationGenerator.genValidPopulation(populationSize);
     }
 
@@ -48,25 +48,17 @@ public class RStatsTest extends SimulationTest {
 
     @Test
     public void testMeanRWithLockdown() {
-        int populationSize = 50000;
-        pop = PopulationGenerator.genValidPopulation(populationSize);
         int startLock = 30;
-        int nDays = 90;
+        int nDays = 60;
         pop.seedVirus(10);
         pop.getLockdownController().addComponent(
                 new FullLockdownEvent(Time.timeFromDay(startLock), pop, 2.0));
         pop.simulate(nDays);
         RStats rs = new RStats(pop);
-        double peakR = 0.0;
 
-        for (int i = 0; i < nDays; i++) {
-            //Get the peak R value before lockdown starts
-            if (i < startLock) peakR = Math.max(peakR, rs.getMeanRBefore(i + 1));
-            //Test that the R value during lockdown is always below the peak R
-            if (i > startLock + 5) {
-                assertTrue("Peak R occurred at Day " + i, rs.getMeanRBefore(i + 1) < peakR);
-            }
-        }
+        double meanRBeforeLockdown = rs.getMeanRBefore(startLock);
+        double meanRDuringLockdown = rs.getMeanRBetween(startLock, nDays);
 
+        assertTrue(meanRDuringLockdown < meanRBeforeLockdown);
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
@@ -48,8 +48,8 @@ public class RStatsTest extends SimulationTest {
 
     @Test
     public void testMeanRWithLockdown() {
-        int startLock = 30;
-        int nDays = 60;
+        int startLock = 20;
+        int nDays = 40;
         pop.seedVirus(10);
         pop.getLockdownController().addComponent(
                 new FullLockdownEvent(Time.timeFromDay(startLock), pop, 2.0));

--- a/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
@@ -50,12 +50,16 @@ public class RStatsTest extends SimulationTest {
     public void testMeanRWithLockdown() {
         int startLock = 20;
         int nDays = 40;
+        // Ensure enough infections for a reasonable R value
         pop.seedVirus(100);
         pop.getLockdownController().addComponent(
                 new FullLockdownEvent(Time.timeFromDay(startLock), pop, 2.0));
         pop.simulate(nDays);
         RStats rs = new RStats(pop);
 
+        // Taking the mean with 10 days before lockdown and 20 days before the end accounts for the fact that
+        // the generation time for COVID is 5-20 days (so the R value can be lower just before
+        // a lockdown/near the end of the run).
         double meanRBeforeLockdown = rs.getMeanRBefore(startLock - 10);
         double meanRDuringLockdown = rs.getMeanRBetween(startLock, nDays - 20);
 

--- a/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
@@ -50,14 +50,14 @@ public class RStatsTest extends SimulationTest {
     public void testMeanRWithLockdown() {
         int startLock = 20;
         int nDays = 40;
-        pop.seedVirus(10);
+        pop.seedVirus(100);
         pop.getLockdownController().addComponent(
                 new FullLockdownEvent(Time.timeFromDay(startLock), pop, 2.0));
         pop.simulate(nDays);
         RStats rs = new RStats(pop);
 
-        double meanRBeforeLockdown = rs.getMeanRBefore(startLock);
-        double meanRDuringLockdown = rs.getMeanRBetween(startLock, nDays);
+        double meanRBeforeLockdown = rs.getMeanRBefore(startLock - 10);
+        double meanRDuringLockdown = rs.getMeanRBetween(startLock, nDays - 20);
 
         assertTrue(meanRDuringLockdown < meanRBeforeLockdown);
     }

--- a/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/ConstructionSiteTest.java
@@ -56,7 +56,7 @@ public class ConstructionSiteTest extends SimulationTest {
                 .setnInitialInfections(nInfections)
                 .setExternalInfectionDays(0)
                 .setIters(1)
-                .setnDays(60)
+                .setnDays(20)
                 .setRNGSeed(42)
                 .setNoOutput();
 

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -260,9 +260,9 @@ public class HospitalTest extends SimulationTest {
 
     @Test
     public void hospitalApptsDecreaseDuringLockdown() {
-        int populationSize = 20000;
+        int populationSize = 10000;
         int nInfections = 100;
-        double lockdownAdjust = 0.75;
+        double lockdownAdjust = 0.90;
 
         // Need to force some non-covid hospitals
         PopulationParameters.get().buildingDistribution.populationToHospitalsRatio = 3000;

--- a/src/test/java/uk/co/ramp/covid/simulation/population/TransportTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/TransportTest.java
@@ -18,7 +18,7 @@ public class TransportTest extends SimulationTest {
                 .setnInitialInfections(100)
                 .setExternalInfectionDays(0)
                 .setIters(1)
-                .setnDays(80)
+                .setnDays(20)
                 .setRNGSeed(42)
                 .setNoOutput();
 


### PR DESCRIPTION
Various tweaks to test parameters (mainly to bring down the population sizes) and use of caching to speed up the tests.

Seems to take tests on my machine from about 3:30 -> 1:30.

Note: This is based on the removeParameterFile branch