### PR TITLE
Dynamic Infection Seeding

### DIFF
--- a/parameters/example_model_params_lockdown.json
+++ b/parameters/example_model_params_lockdown.json
@@ -38,6 +38,11 @@
             "socialDistance": 1.0,
             "keyPremises": 1.0,
             "pAttendsSchool": 1.0
+        },
+        {
+            "type": "TravelEasing",
+            "start": 200,
+            "pTravelSeed": 0.000001
         }
     ],
     "lockdownGenerators": [

--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -174,8 +174,8 @@ public class Model {
                 }
             }
 
-            p.setExternalInfectionDays(externalInfectionDays);
-            p.seedVirus(nInitialInfections);
+            p.getSeeder().setExternalInfectionDays(externalInfectionDays);
+            p.getSeeder().forceNInfections(nInitialInfections);
 
             for (LockdownEventGenerator gen : lockdownGenerators) {
                 gen.setPopulation(p);

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/FullLockdownEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/FullLockdownEvent.java
@@ -38,6 +38,9 @@ public class FullLockdownEvent extends LockdownEvent {
 
         // Log initial R if needed
         population.setShouldPrintR();
+
+        // Travel restrictions during lockdown
+        population.getSeeder().stopTravelSeeding();
     }
 
 

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownTypeMaps.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownTypeMaps.java
@@ -17,6 +17,7 @@ public class LockdownTypeMaps {
         components.put("ShopEasing", ShopEasingEvent.class);
         components.put("RestaurantEasing", RestaurantEasingEvent.class);
         components.put("HouseholdEasing", HouseholdEasingEvent.class);
+        components.put("TravelEasing", TravelEasingEvent.class);
         return components;
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/TravelEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/TravelEasingEvent.java
@@ -6,7 +6,7 @@ import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.Time;
 
 public class TravelEasingEvent extends LockdownEvent {
-    final Probability pTravelSeed;
+    private final Probability pTravelSeed;
 
     public TravelEasingEvent(Time start, Population p, Probability pTravelSeed) {
         super(start, p);

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/TravelEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/TravelEasingEvent.java
@@ -1,0 +1,30 @@
+package uk.co.ramp.covid.simulation.lockdown.easingevents;
+
+import uk.co.ramp.covid.simulation.lockdown.LockdownEvent;
+import uk.co.ramp.covid.simulation.population.Population;
+import uk.co.ramp.covid.simulation.util.Probability;
+import uk.co.ramp.covid.simulation.util.Time;
+
+public class TravelEasingEvent extends LockdownEvent {
+    final Probability pTravelSeed;
+
+    public TravelEasingEvent(Time start, Population p, Probability pTravelSeed) {
+        super(start, p);
+        this.pTravelSeed = pTravelSeed;
+    }
+
+    @Override
+    protected void apply() {
+        population.getSeeder().startTravelSeeding(pTravelSeed);
+    }
+
+    @Override
+    protected String getName() {
+        return "Travel Easing";
+    }
+
+    @Override
+    protected boolean isValid() {
+        return pTravelSeed != null;
+    }
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/population/InfectionSeeder.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/InfectionSeeder.java
@@ -50,10 +50,9 @@ public class InfectionSeeder {
         int i = 0;
         while (i < n) {
             int nInt = RNG.get().nextInt(0, households.size() - 1);
-            if (households.get(nInt).getHouseholdSize() > 0) {
-                if (households.get(nInt).seedInfection()) {
-                    i++;
-                }
+            if (households.get(nInt).getHouseholdSize() > 0
+                    && households.get(nInt).seedInfection()) {
+                i++;
             }
         }
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/InfectionSeeder.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/InfectionSeeder.java
@@ -1,0 +1,74 @@
+package uk.co.ramp.covid.simulation.population;
+
+import uk.co.ramp.covid.simulation.output.DailyStats;
+import uk.co.ramp.covid.simulation.place.Household;
+import uk.co.ramp.covid.simulation.util.Probability;
+import uk.co.ramp.covid.simulation.util.RNG;
+import uk.co.ramp.covid.simulation.util.Time;
+
+import java.util.List;
+
+/** The Infection Seeder class handles both direct infections and
+ * external infections (to simulate movement from outwith the model) */
+public class InfectionSeeder {
+
+    private final Population population;
+    private int externalInfectionDays = 0;
+    private boolean travelSeeding = false;
+    private Probability pTravelSeeding;
+    
+    public InfectionSeeder(Population population) {
+        this.population = population;
+    }
+
+    // ExternalSeeding runs from 0-externalInfectionDays inclusive.
+    // As infections on day 0 are 0 this gives a full externalInfectionsDays worth of infections.
+    private void seedExternal(Time t, DailyStats s) {
+        if (t.getAbsDay() <= externalInfectionDays) {
+            for (Person p : population.getAllPeople()) {
+                p.seedInfectionChallenge(t, s);
+            }
+        }
+    }
+
+    public void seedInfections(Time t, DailyStats s) {
+       seedExternal(t, s);
+       seedTravel(t, s);
+    }
+
+    /** Travel seeding using a fixed probability of infection */
+    private void seedTravel(Time t, DailyStats s) {
+        if (travelSeeding) {
+            for (Person p : population.getAllPeople()) {
+                p.seedInfectionChallenge(pTravelSeeding, t, s);
+            }
+        }
+    }
+    
+    public void forceNInfections(int n) {
+        List<Household> households = population.getHouseholds();
+        int i = 0;
+        while (i < n) {
+            int nInt = RNG.get().nextInt(0, households.size() - 1);
+            if (households.get(nInt).getHouseholdSize() > 0) {
+                if (households.get(nInt).seedInfection()) {
+                    i++;
+                }
+            }
+        }
+    }
+    
+    public void setExternalInfectionDays(int days) {
+        this.externalInfectionDays = days;
+    }
+
+    public void startTravelSeeding(Probability pTravelSeeding) {
+        this.pTravelSeeding = pTravelSeeding;
+        this.travelSeeding = true;
+    }
+
+    public void stopTravelSeeding() {
+        this.travelSeeding = false;
+    }
+    
+}

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -336,8 +336,13 @@ public abstract class Person {
     }
 
     public void seedInfectionChallenge(Time t, DailyStats s) {
-        Probability infectionChance = new Probability(getInfectionSeedInitial() * Math.pow(getInfectionSeedRate(), t.getAbsDay()) * this.covidSusceptibleVal);
-        if (infectionChance.sample()) {
+        double dayAdjust = Math.pow(getInfectionSeedRate(), t.getAbsDay());
+        Probability infectionChance = new Probability(getInfectionSeedInitial() * dayAdjust * covidSusceptibleVal);
+        seedInfectionChallenge(infectionChance, t, s);
+    }
+
+    public void seedInfectionChallenge(Probability p, Time t, DailyStats s) {
+        if (p.sample()) {
             cVirus = new Covid(this);
             cVirus.getInfectionLog().registerInfected(t);
             s.incSeedInfections();

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -43,8 +43,7 @@ public class Population {
     private final InfectionSeeder seeder;
 
     private final RandomDataGenerator rng;
-    private Integer externalInfectionDays = 0;
-    
+
     private boolean rPrinted = false;
     private boolean shouldPrintR = false;
 
@@ -330,11 +329,6 @@ public class Population {
     }
 
 
-    // Force infections into a defined number of people
-    public void seedVirus(int nInfections) {
-       seeder.forceNInfections(nInfections);
-    }
-    
     public void timeStep(Time t, DailyStats dStats) {
         timeStep(t, dStats, null);
     }
@@ -468,10 +462,6 @@ public class Population {
 
     public Places getPlaces() {
         return places;
-    }
-
-    public void setExternalInfectionDays(Integer days) {
-        seeder.setExternalInfectionDays(days);
     }
 
     public LockdownController getLockdownController() {

--- a/src/test/java/uk/co/ramp/covid/simulation/covid/CovidTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/covid/CovidTest.java
@@ -115,7 +115,7 @@ public class CovidTest extends SimulationTest {
     public void testCovidStatus() throws ImpossibleWorkerDistributionException {
         int populationSize = 12000;
         Population p = PopulationGenerator.genValidPopulation(populationSize);
-        p.seedVirus(100);
+        p.getSeeder().forceNInfections(100);
         p.allocatePeople();
         
         p.setPostHourHook((pop, time) -> {

--- a/src/test/java/uk/co/ramp/covid/simulation/covid/InfectionLogTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/covid/InfectionLogTest.java
@@ -22,7 +22,7 @@ public class InfectionLogTest extends SimulationTest {
 
     @Test
     public void secondaryInfectionsAreLogged() {
-        pop.seedVirus(10);
+        pop.getSeeder().forceNInfections(10);
         pop.simulate(20);
         int totalSecondary = 0;
         for (Person p : pop.getAllPeople()) {
@@ -35,7 +35,7 @@ public class InfectionLogTest extends SimulationTest {
 
     @Test
     public void symptomaticCasesAreLogged() {
-        pop.seedVirus(1);
+        pop.getSeeder().forceNInfections(1);
 
         Person infected = null;
         for (Person p : pop.getAllPeople()) {

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -32,7 +32,7 @@ public class MovementTest extends SimulationTest {
         PopulationParameters.get().householdProperties.pWillIsolate = new Probability(1.0);
 
         p = PopulationGenerator.genValidPopulation(populationSize);
-        p.seedVirus(nInfections);
+        p.getSeeder().forceNInfections(nInfections);
     }
 
     @Test
@@ -138,7 +138,7 @@ public class MovementTest extends SimulationTest {
         CovidParameters.get().diseaseParameters.pensionerProgressionPhase2 = 100.0;
 
         p = PopulationGenerator.genValidPopulation(populationSize);
-        p.seedVirus(200);
+        p.getSeeder().forceNInfections(200);
 
         Set<Person> visiting = new HashSet<>();
 
@@ -323,7 +323,7 @@ public class MovementTest extends SimulationTest {
     @Test
     public void somePeopleGetTested() {
         // As most tests are positive we force lots of infections to check some go negative.
-        p.seedVirus(100);
+        p.getSeeder().forceNInfections(100);
         CovidParameters.get().testParameters.pDiagnosticTestAvailable = new Probability(1.0);
         p.simulate(30);
 
@@ -392,7 +392,7 @@ public class MovementTest extends SimulationTest {
         PopulationParameters.get().personProperties.pQuarantinesIfSymptomatic = new Probability(1.0);
         CovidParameters.get().diseaseParameters.adultProgressionPhase2 = 100.0;
         p = PopulationGenerator.genValidPopulation(populationSize);
-        p.seedVirus(nInfections);
+        p.getSeeder().forceNInfections(nInfections);
 
         Household iso = null;
         for (Household h : p.getHouseholds()) {
@@ -427,7 +427,7 @@ public class MovementTest extends SimulationTest {
     public void neighboursShouldLeaveEmptyHouses() {
         final int simDays = 5;
         p = PopulationGenerator.genValidPopulation(populationSize);
-        p.seedVirus(nInfections);
+        p.getSeeder().forceNInfections(nInfections);
 
         // Going to an empty neighbours house is okay, but only for 1 hour (when you discover they aren't in)
         List<Set<Person>> inEmptyNeighbourHouse = new ArrayList<>();
@@ -455,8 +455,8 @@ public class MovementTest extends SimulationTest {
         final int simDays = 5;
 
         p = PopulationGenerator.genValidPopulation(populationSize);
-        p.seedVirus(nInfections);
-        
+        p.getSeeder().forceNInfections(nInfections);
+
         p.setPostHourHook((pop, time) -> {
             Set<Person> seen = new HashSet<>();
 
@@ -484,7 +484,7 @@ public class MovementTest extends SimulationTest {
         // We need to force > 1 hospital, else it will be designated COVID and no accept patients
         PopulationParameters.get().buildingDistribution.populationToHospitalsRatio = 5000;
         p = PopulationGenerator.genValidPopulation(populationSize);
-        p.seedVirus(nInfections);
+        p.getSeeder().forceNInfections(nInfections);
 
         // Final arrays to allow variable capture in the lambda
         final int[] hospitalApptVisitors = {0};

--- a/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/RStatsTest.java
@@ -1,15 +1,12 @@
 package uk.co.ramp.covid.simulation.output;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.lockdown.FullLockdownEvent;
 import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.util.PopulationGenerator;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Time;
-
-import java.sql.Timestamp;
 
 import static org.junit.Assert.*;
 
@@ -25,7 +22,7 @@ public class RStatsTest extends SimulationTest {
 
     @Test
     public void meanRWithNoInfectionsIsNull() {
-        pop.seedVirus(0);
+        pop.getSeeder().forceNInfections(0);
         pop.simulate(20);
         RStats rs = new RStats(pop);
 
@@ -37,7 +34,7 @@ public class RStatsTest extends SimulationTest {
 
     @Test
     public void meanRPositiveWhenInfectionsOccur() {
-        pop.seedVirus(20);
+        pop.getSeeder().forceNInfections(20);
         pop.simulate(20);
         RStats rs = new RStats(pop);
 
@@ -52,7 +49,7 @@ public class RStatsTest extends SimulationTest {
         pop = PopulationGenerator.genValidPopulation(populationSize);
         int startLock = 30;
         int nDays = 90;
-        pop.seedVirus(10);
+        pop.getSeeder().forceNInfections(10);
         pop.getLockdownController().addComponent(
                 new FullLockdownEvent(Time.timeFromDay(startLock), pop, 2.0));
         pop.simulate(nDays);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/CareHomeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/CareHomeTest.java
@@ -65,7 +65,7 @@ public class CareHomeTest extends SimulationTest {
         CovidParameters.get().diseaseParameters.meanLatentPeriod = 0.5;
 
         Population pop = PopulationGenerator.genValidPopulation(populationSize);
-        pop.seedVirus(100);
+        pop.getSeeder().forceNInfections(100);
 
         // Find a pensioner to infect
         Pensioner inf = null;

--- a/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/HospitalTest.java
@@ -1,6 +1,5 @@
 package uk.co.ramp.covid.simulation.place;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.gson.JsonParseException;
@@ -60,7 +59,7 @@ public class HospitalTest extends SimulationTest {
         CovidParameters.get().diseaseParameters.caseMortalityRate = 0.0;
 
         Population pop = PopulationGenerator.genValidPopulation(populationSize);
-        pop.seedVirus(nInfections);
+        pop.getSeeder().forceNInfections(nInfections);
 
         Person inf = null;
         for (Person p : pop.getAllPeople()) {
@@ -125,7 +124,7 @@ public class HospitalTest extends SimulationTest {
         CovidParameters.get().diseaseParameters.pensionerProgressionPhase2 = 100.0;
 
         Population pop = PopulationGenerator.genValidPopulation(populationSize);
-        pop.seedVirus(nInfections);
+        pop.getSeeder().forceNInfections(nInfections);
 
         pop.setPostHourHook((population, time) -> {
             for (CovidHospital h : population.getPlaces().getCovidHospitals()) {
@@ -148,7 +147,7 @@ public class HospitalTest extends SimulationTest {
         CovidParameters.get().diseaseParameters.caseMortalityRate = 0.0;
 
         Population pop = PopulationGenerator.genValidPopulation(populationSize);
-        pop.seedVirus(nInfections);
+        pop.getSeeder().forceNInfections(nInfections);
 
         Person inf = null;
         for (Person p : pop.getAllPeople()) {
@@ -188,7 +187,7 @@ public class HospitalTest extends SimulationTest {
         // Need to force some non-covid hospitals
         PopulationParameters.get().buildingDistribution.populationToHospitalsRatio = 3000;
         Population pop = PopulationGenerator.genValidPopulation(populationSize);
-        pop.seedVirus(nInfections);
+        pop.getSeeder().forceNInfections(nInfections);
 
         Set<Person> hospitalWorkersPreLockdown = new HashSet<>();
         pop.simulate(1);
@@ -234,8 +233,8 @@ public class HospitalTest extends SimulationTest {
         // Need to force some non-covid hospitals
         PopulationParameters.get().buildingDistribution.populationToHospitalsRatio = 3000;
         Population pop = PopulationGenerator.genValidPopulation(populationSize);
-        pop.seedVirus(nInfections);
-        
+        pop.getSeeder().forceNInfections(nInfections);
+
         pop.setPostHourHook((population, time) -> {
             for (Hospital h : population.getPlaces().getAllHospitals()) {
                 for (Person p : h.getPeople()) {
@@ -268,7 +267,7 @@ public class HospitalTest extends SimulationTest {
         PopulationParameters.get().buildingDistribution.populationToHospitalsRatio = 3000;
         PopulationParameters.get().hospitalApptProperties.lockdownApptDecreasePercentage = lockdownAdjust;
         Population pop = PopulationGenerator.genValidPopulation(populationSize);
-        pop.seedVirus(nInfections);
+        pop.getSeeder().forceNInfections(nInfections);
 
         pop.getLockdownController().addComponent(new FullLockdownEvent(Time.timeFromDay(15), pop, 1.0));
 

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -198,7 +198,7 @@ public class PopulationTest extends SimulationTest {
     public void testSeedVirus() {
         int nInfections = 10;
         int nInfected = 0;
-        pop.seedVirus(nInfections);
+        pop.getSeeder().forceNInfections(nInfections);
 
         //Check that there are just 10 infections amongst the population
         for (Person p : pop.getAllPeople()) {


### PR DESCRIPTION
Allows seeding to be dynamically re-enabled after a lockdown to simulate travel restrictions being lifted etc.

There's some general tidy up around seeding too.

We may revisit exactly how seeding probabilities are calculated in future (rather than just fixed - as Paul has initially suggested), but this should be flexible in that regard.