### PR TITLE
Refactor Places to manage Households and Place construction

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/FullLockdownEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/FullLockdownEvent.java
@@ -18,7 +18,7 @@ public class FullLockdownEvent extends LockdownEvent {
 
     @Override
     protected void apply() {
-        for (CommunalPlace cPlace : population.getPlaces().getAllPlaces()) {
+        for (CommunalPlace cPlace : population.getPlaces().getCommunalPlaces()) {
             cPlace.enterLockdown(socialDistance);
         }
         

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/FullLockdownEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/FullLockdownEasingEvent.java
@@ -15,7 +15,7 @@ public class FullLockdownEasingEvent extends LockdownEvent {
 
     @Override
     protected void apply() {
-        for (CommunalPlace cPlace : population.getPlaces().getAllPlaces()) {
+        for (CommunalPlace cPlace : population.getPlaces().getCommunalPlaces()) {
             cPlace.exitLockdown();
         }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Household.java
@@ -221,7 +221,7 @@ public abstract class Household extends Place implements Home {
 
     private void moveHospital(Time t) {
         for (Person p : getPeople() ) {
-            if (p.hasMoved() || !p.hasHospitalAppt()) {
+            if (p.hasMoved() || !isInhabitant(p) || !p.hasHospitalAppt()) {
                 continue;
             }
 
@@ -229,7 +229,8 @@ public abstract class Household extends Place implements Home {
                // Children need to find an adult to go with them else they don't go
                if (p instanceof Child || p instanceof Infant) {
                    for (Person per : getPeople() ) {
-                       if (per != p && (per instanceof Adult || per instanceof Pensioner)
+                       if (per != p && isInhabitant(p)
+                               && (per instanceof Adult || per instanceof Pensioner)
                                && !per.hasMoved() && !per.hasHospitalAppt()) {
                            // Giving them the same appt ensures they leave at the same time
                            per.setHospitalAppt(p.getHospitalAppt());

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
@@ -5,9 +5,7 @@ import uk.co.ramp.covid.simulation.place.*;
 import uk.co.ramp.covid.simulation.util.ProbabilityDistribution;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -35,7 +33,8 @@ public class Places {
     private boolean shopsUnallocated = false;
     private boolean careHomeUnallocated = false;
 
-    private final List<CommunalPlace> all;
+    private final List<Place> allPlaces;
+    private final List<CommunalPlace> communalPlaces;
     private final List<Household> households;
     
     public Places() {
@@ -43,6 +42,12 @@ public class Places {
     }
 
     public Places(int numHouseholds) {
+        communalPlaces = new ArrayList<>();
+        allPlaces = new ArrayList<>();
+        households = new ArrayList<>(numHouseholds);
+
+        createHouseholds(numHouseholds);
+
         offices = new ProbabilityDistribution<>();
         constructionSites = new ProbabilityDistribution<>();
         allHospitals = new ProbabilityDistribution<>();
@@ -53,9 +58,6 @@ public class Places {
         schools = new ProbabilityDistribution<>();
         shops = new ProbabilityDistribution<>();
         careHomes = new ProbabilityDistribution<>();
-        households = new ArrayList<>(numHouseholds);
-        createHouseholds(numHouseholds);
-        all = new ArrayList<>();
     }
 
     private void createHouseholds(int numHouseholds) {
@@ -63,7 +65,9 @@ public class Places {
                 PopulationParameters.get().householdDistribution.householdTypeDistribution();
 
         for (int i = 0; i < numHouseholds; i++) {
-            households.add(p.sample().get());
+            Household h = p.sample().get();
+            households.add(h);
+            allPlaces.add(h);
         }
     }
 
@@ -185,7 +189,8 @@ public class Places {
             }
             places.add(constructorN.apply(size, i));
         }
-        all.addAll(places);
+        communalPlaces.addAll(places);
+        allPlaces.addAll(places);
 
         // In the case of 0 buildings we need to expand the probabilities to fill the distribution
         createPlaceDistribution(finalDist, places, s, m, l);
@@ -339,8 +344,12 @@ public class Places {
         createNGeneric((s, x) -> new CareHome(s), n, p, careHomes);
     }
 
-    public List<CommunalPlace> getAllPlaces() {
-        return this.all;
+    public List<CommunalPlace> getCommunalPlaces() {
+        return this.communalPlaces;
+    }
+
+    public List<Place> getAllPlaces() {
+        return this.allPlaces;
     }
 
     public List<Office> getOffices() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Places.java
@@ -36,8 +36,13 @@ public class Places {
     private boolean careHomeUnallocated = false;
 
     private final List<CommunalPlace> all;
-
+    private final List<Household> households;
+    
     public Places() {
+        this(0);
+    }
+
+    public Places(int numHouseholds) {
         offices = new ProbabilityDistribution<>();
         constructionSites = new ProbabilityDistribution<>();
         allHospitals = new ProbabilityDistribution<>();
@@ -48,7 +53,18 @@ public class Places {
         schools = new ProbabilityDistribution<>();
         shops = new ProbabilityDistribution<>();
         careHomes = new ProbabilityDistribution<>();
+        households = new ArrayList<>(numHouseholds);
+        createHouseholds(numHouseholds);
         all = new ArrayList<>();
+    }
+
+    private void createHouseholds(int numHouseholds) {
+        ProbabilityDistribution<Supplier<Household>> p =
+                PopulationParameters.get().householdDistribution.householdTypeDistribution();
+
+        for (int i = 0; i < numHouseholds; i++) {
+            households.add(p.sample().get());
+        }
     }
 
     public Office getRandomOffice() {
@@ -365,6 +381,10 @@ public class Places {
 
     public List<CareHome> getCareHomes() {
         return careHomes.toList();
+    }
+
+    public List<Household> getHouseholds() {
+        return households;
     }
 
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -63,7 +63,7 @@ public class Population {
         }
         
         this.allPeople = new ArrayList<>(populationSize);
-        this.places = new Places(numHouseholds);
+        this.places = new Places(populationSize, numHouseholds);
 
         postHourHook = (p,t) -> {};
 
@@ -78,7 +78,6 @@ public class Population {
     
     private void allocatePopulation() throws ImpossibleAllocationException, ImpossibleWorkerDistributionException {
         populateHouseholds();
-        createMixing();
         allocatePeople();
         allocateCareHomes();
         assignNeighbours();
@@ -205,28 +204,7 @@ public class Population {
 
     }
 
-    // This creates the Communal places of different types where people mix
-    private void createMixing() {
-        int nHospitals = populationSize / PopulationParameters.get().buildingDistribution.populationToHospitalsRatio;
-        int nSchools = populationSize / PopulationParameters.get().buildingDistribution.populationToSchoolsRatio;
-        int nShops = populationSize / PopulationParameters.get().buildingDistribution.populationToShopsRatio;
-        int nOffices = populationSize / PopulationParameters.get().buildingDistribution.populationToOfficesRatio;
-        int nConstructionSites = populationSize / PopulationParameters.get().buildingDistribution.populationToConstructionSitesRatio;
-        int nNurseries = populationSize / PopulationParameters.get().buildingDistribution.populationToNurseriesRatio;
-        int nRestaurants = populationSize / PopulationParameters.get().buildingDistribution.populationToRestaurantsRatio;
-        int nCareHomes = populationSize / PopulationParameters.get().buildingDistribution.populationToCareHomesRatio;
 
-        places.createNHospitals(nHospitals);
-        places.createNSchools(nSchools);
-        places.createNShops(nShops);
-        places.createNOffices(nOffices);
-        places.createNConstructionSites(nConstructionSites);
-        places.createNNurseries(nNurseries);
-        places.createNRestaurants(nRestaurants);
-        places.createNCareHomes(nCareHomes);
-
-        LOGGER.info("Total number of establishments = {}", places.getCommunalPlaces().size());
-    }
 
     // Allocates people to communal places - work environments
     public void allocatePeople() throws ImpossibleWorkerDistributionException {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Population.java
@@ -225,7 +225,7 @@ public class Population {
         places.createNRestaurants(nRestaurants);
         places.createNCareHomes(nCareHomes);
 
-        LOGGER.info("Total number of establishments = {}", places.getAllPlaces().size());
+        LOGGER.info("Total number of establishments = {}", places.getCommunalPlaces().size());
     }
 
     // Allocates people to communal places - work environments
@@ -237,7 +237,7 @@ public class Population {
         }
 
         // Sometimes given parameters/randomness it's not possible to staff everywhere. In this case we throw an error.
-        for (CommunalPlace p : places.getAllPlaces()) {
+        for (CommunalPlace p : places.getCommunalPlaces()) {
             if (!p.isFullyStaffed()) {
                 throw new ImpossibleWorkerDistributionException("Not enough workers to fill required positions");
             }
@@ -320,11 +320,8 @@ public class Population {
     }
     
     public void timeStep(Time t, DailyStats dStats, ContactsWriter contactsWriter) {
-        // Movement places people in "next" buffers (to avoid people moving twice in an hour)
         for (Household h : places.getHouseholds()) {
             h.handleSymptomaticCases(t);
-            h.doInfect(t, dStats, contactsWriter);
-            h.determineMovement(t, dStats, getPlaces());
         }
 
         for (Place p : places.getAllPlaces()) {
@@ -333,10 +330,6 @@ public class Population {
         }
 
         publicTransport.doInfect(t, dStats, contactsWriter);
-        
-        for (Household h : places.getHouseholds()) {
-            h.commitMovement();
-        }
 
         for (Place p : places.getAllPlaces()) {
             p.commitMovement();

--- a/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/integrationTests/MovementTest.java
@@ -79,7 +79,7 @@ public class MovementTest extends SimulationTest {
         Set<Adult> working = new HashSet<>();
         
         p.setPostHourHook((pop, time) -> {
-            for (CommunalPlace place : pop.getPlaces().getAllPlaces()) {
+            for (CommunalPlace place : pop.getPlaces().getCommunalPlaces()) {
                 for (Person per : place.getPeople()) {
                     if (per instanceof Adult) {
                         working.add((Adult) per);
@@ -176,7 +176,7 @@ public class MovementTest extends SimulationTest {
     public void weDontLosePeople() {
         p.setPostHourHook((pop, time) -> {
             int npeople = 0;
-            for (Place place : pop.getPlaces().getAllPlaces()) {
+            for (Place place : pop.getPlaces().getCommunalPlaces()) {
                 npeople += place.getNumPeople();
             }
 
@@ -193,7 +193,7 @@ public class MovementTest extends SimulationTest {
     public void openPlacesShouldBeStaffed() {
 
         p.setPostHourHook((pop, time) -> {
-            for (CommunalPlace place : pop.getPlaces().getAllPlaces()) {
+            for (CommunalPlace place : pop.getPlaces().getCommunalPlaces()) {
                 List<Person> staff = place.getStaff(time);
                 if (place.isOpen(time)) {
                     assertTrue("No staff found in open place", staff.size() > 0);
@@ -206,7 +206,7 @@ public class MovementTest extends SimulationTest {
     }
 
     private void doesNotGoOut(Household iso, List<Person> isolating) {
-        for (CommunalPlace place : p.getPlaces().getAllPlaces()) {
+        for (CommunalPlace place : p.getPlaces().getCommunalPlaces()) {
             for (Person per : isolating) {
                 if (per.isHospitalised()) {
                     continue;
@@ -257,7 +257,7 @@ public class MovementTest extends SimulationTest {
         // Since arrays pass by reference this allows updating inside the lambda
         final Integer[] excursions = {0};
         p.setPostHourHook((pop, time) -> {
-            for (CommunalPlace place : pop.getPlaces().getAllPlaces()) {
+            for (CommunalPlace place : pop.getPlaces().getCommunalPlaces()) {
                 for (Person per : isolating) {
                     if (place.personInPlace(per)) {
                         excursions[0]++;
@@ -460,7 +460,7 @@ public class MovementTest extends SimulationTest {
         p.setPostHourHook((pop, time) -> {
             Set<Person> seen = new HashSet<>();
 
-            for (Place place : p.getPlaces().getAllPlaces()) {
+            for (Place place : p.getPlaces().getCommunalPlaces()) {
                 for (Person per : place.getPeople()) {
                     assertTrue(seen.add(per));
                 }

--- a/src/test/java/uk/co/ramp/covid/simulation/place/CommunalPlaceTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/CommunalPlaceTest.java
@@ -31,7 +31,7 @@ public class CommunalPlaceTest extends SimulationTest {
     @Test
     public void testAllPlaces() {
         p.setPostHourHook((pop, time) -> {
-            for (CommunalPlace place : pop.getPlaces().getAllPlaces()) {
+            for (CommunalPlace place : pop.getPlaces().getCommunalPlaces()) {
                 // Get place opening and closing time
                 int open = place.getTimes().getOpen();
                 int close = place.getTimes().getClose();

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
@@ -1,5 +1,6 @@
 package uk.co.ramp.covid.simulation.population;
 
+import org.junit.Before;
 import org.junit.Test;
 import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.place.*;
@@ -12,13 +13,29 @@ import static org.junit.Assert.*;
 
 public class PlacesTest extends SimulationTest {
 
+    private Places p;
+    private int population = 20000;
+    private int iters = 2000; // samples to take for random testing
+    private int n = 200;
+    private double DELTA = 0.05;
+    
+    @Before
+    public void createPlaces() {
+        // Force it so we expect a fixed number of places of each type
+        PopulationParameters.get().buildingDistribution.populationToHospitalsRatio = population / n;
+        PopulationParameters.get().buildingDistribution.populationToShopsRatio = population / n;
+        PopulationParameters.get().buildingDistribution.populationToSchoolsRatio = population / n;
+        PopulationParameters.get().buildingDistribution.populationToRestaurantsRatio = population / n;
+        PopulationParameters.get().buildingDistribution.populationToOfficesRatio = population / n;
+        PopulationParameters.get().buildingDistribution.populationToConstructionSitesRatio = population / n;
+        PopulationParameters.get().buildingDistribution.populationToCareHomesRatio = population / n;
+        PopulationParameters.get().buildingDistribution.populationToNurseriesRatio = population / n;
+        
+        p = new Places(population, 0);
+    }
+
     @Test
     public void getRandomOffice() {
-        int n = 100;
-        int iters = 10000; // Number of samples to try
-        Places p = new Places();
-        p.createNOffices(n);
-
         List<Office> samples = new ArrayList<>();
         for (int i = 0; i < iters ; i++) {
             samples.add(p.getRandomOffice());
@@ -38,7 +55,6 @@ public class PlacesTest extends SimulationTest {
         assertTrue("We should sample large offices more often than medium", l > m);
         assertTrue("We should sample medium offices more often than small", m > s);
 
-        double DELTA = 0.02;
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pLarge.asDouble(),  (double) l/ (double) iters, DELTA);
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pMed.asDouble(), (double) m / (double) iters, DELTA);
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pSmall.asDouble(), (double) s / (double) iters, DELTA);
@@ -46,11 +62,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getRandomConstructionSite() {
-        int n = 100;
-        int iters = 10000; // Number of samples to try
-        Places p = new Places();
-        p.createNConstructionSites(n);
-
         List<ConstructionSite> samples = new ArrayList<>();
         for (int i = 0; i < iters ; i++) {
             samples.add(p.getRandomConstructionSite());
@@ -70,7 +81,7 @@ public class PlacesTest extends SimulationTest {
         assertTrue("We should sample large constructionSites more often than medium", l > m);
         assertTrue("We should sample medium constructionSites more often than small", m > s);
 
-        double DELTA = 0.02;
+       
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pLarge.asDouble(),  (double) l/ (double) iters, DELTA);
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pMed.asDouble(), (double) m / (double) iters, DELTA);
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pSmall.asDouble(), (double) s / (double) iters, DELTA);
@@ -78,11 +89,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getRandomHospital() {
-        int n = 100;
-        int iters = 10000; // Number of samples to try
-        Places p = new Places();
-        p.createNHospitals(n);
-
         List<Hospital> samples = new ArrayList<>();
         for (int i = 0; i < iters ; i++) {
             samples.add(p.getRandomHospital());
@@ -103,11 +109,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getRandomNursery() {
-        int n = 100;
-        int iters = 10000; // Number of samples to try
-        Places p = new Places();
-        p.createNNurseries(n);
-
         List<Nursery> samples = new ArrayList<>();
         for (int i = 0; i < iters ; i++) {
             samples.add(p.getRandomNursery());
@@ -128,11 +129,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getRandomRestaurant() {
-        int n = 100;
-        int iters = 10000; // Number of samples to try
-        Places p = new Places();
-        p.createNRestaurants(n);
-
         List<Restaurant> samples = new ArrayList<>();
         for (int i = 0; i < iters ; i++) {
             samples.add(p.getRandomRestaurant());
@@ -152,7 +148,6 @@ public class PlacesTest extends SimulationTest {
         assertTrue("We should sample large restaurants more often than medium", l > m);
         assertTrue("We should sample medium restaurants more often than small", m > s);
 
-        double DELTA = 0.02;
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pLarge.asDouble(),  (double) l/ (double) iters, DELTA);
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pMed.asDouble(), (double) m / (double) iters, DELTA);
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pSmall.asDouble(), (double) s / (double) iters, DELTA);
@@ -160,11 +155,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getRandomSchool() {
-        int n = 100;
-        int iters = 10000; // Number of samples to try
-        Places p = new Places();
-        p.createNSchools(n);
-
         List<School> samples = new ArrayList<>();
         for (int i = 0; i < iters ; i++) {
             samples.add(p.getRandomSchool());
@@ -185,11 +175,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getRandomShop() {
-        int n = 100;
-        int iters = 10000; // Number of samples to try
-        Places p = new Places();
-        p.createNShops(n);
-
         List<Shop> samples = new ArrayList<>();
         for (int i = 0; i < iters ; i++) {
             samples.add(p.getRandomShop());
@@ -209,18 +194,33 @@ public class PlacesTest extends SimulationTest {
         assertTrue("We should sample large shops more often than medium", l > m);
         assertTrue("We should sample medium shops more often than small", m > s);
 
-        double DELTA = 0.02;
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pLarge.asDouble(),  (double) l/ (double) iters, DELTA);
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pMed.asDouble(), (double) m / (double) iters, DELTA);
         assertEquals(PopulationParameters.get().workerDistribution.sizeAllocation.pSmall.asDouble(), (double) s / (double) iters, DELTA);
     }
 
     @Test
-    public void createNOffices() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNOffices(n);
+    public void getRandomCareHome() {
+        List<CareHome> samples = new ArrayList<>();
+        for (int i = 0; i < iters ; i++) {
+            samples.add(p.getRandomCareHome());
+        }
 
+        int s = 0, m = 0, l = 0;
+        for (CareHome o : samples) {
+            switch (o.getSize()) {
+                case SMALL: s++; break;
+                case MED: m++; break;
+                case LARGE: l++; break;
+            }
+        }
+
+        assertTrue("We only have medium careHomes", s == 0 && m > 0 && l == 0);
+        assertEquals(iters, m);
+    }
+
+    @Test
+    public void createNOffices() {
         int s = 0, m = 0, l = 0;
         for (Office o : p.getOffices()) {
             switch (o.getSize()) {
@@ -239,10 +239,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void createNHospitals() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNHospitals(n);
-
         int s = 0, m = 0, l = 0;
         for (Hospital o : p.getAllHospitals()) {
             switch (o.getSize()) {
@@ -261,10 +257,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void createNSchools() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNSchools(n);
-
         int s = 0, m = 0, l = 0;
         for (School o : p.getSchools()) {
             switch (o.getSize()) {
@@ -283,10 +275,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void createNNurseries() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNNurseries(n);
-
         int s = 0, m = 0, l = 0;
         for (Nursery o : p.getNurseries()) {
             switch (o.getSize()) {
@@ -305,10 +293,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void createNRestaurants() {
-        int n = 10000;
-        Places p = new Places();
-        p.createNRestaurants(n);
-
         int s = 0, m = 0, l = 0;
         for (Restaurant o : p.getRestaurants()) {
             switch (o.getSize()) {
@@ -326,10 +310,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void createNShops() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNShops(n);
-
         int s = 0, m = 0, l = 0;
         for (Shop o : p.getShops()) {
             switch (o.getSize()) {
@@ -348,10 +328,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void createNConstructionSites() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNConstructionSites(n);
-
         int s = 0, m = 0, l = 0;
         for (ConstructionSite o : p.getConstructionSites()) {
             switch (o.getSize()) {
@@ -370,17 +346,7 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getAllPlaces() {
-        int n = 100;
-        Places p = new Places();
-        p.createNOffices(n);
-        p.createNShops(n);
-        p.createNRestaurants(n);
-        p.createNNurseries(n);
-        p.createNHospitals(n);
-        p.createNConstructionSites(n);
-        p.createNSchools(n);
-
-        assertEquals(n*7, p.getCommunalPlaces().size());
+        assertEquals(n*8, p.getCommunalPlaces().size());
         assertTrue(p.getCommunalPlaces().containsAll(p.getOffices()));
         assertTrue(p.getCommunalPlaces().containsAll(p.getConstructionSites()));
         assertTrue(p.getCommunalPlaces().containsAll(p.getAllHospitals()));
@@ -388,15 +354,11 @@ public class PlacesTest extends SimulationTest {
         assertTrue(p.getCommunalPlaces().containsAll(p.getRestaurants()));
         assertTrue(p.getCommunalPlaces().containsAll(p.getSchools()));
         assertTrue(p.getCommunalPlaces().containsAll(p.getShops()));
-
+        assertTrue(p.getCommunalPlaces().containsAll(p.getCareHomes()));
     }
 
     @Test
     public void getOffices() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNOffices(n);
-        
         List<Office> offices = p.getOffices();
         assertEquals(n, offices.size());
         assertTrue(p.getCommunalPlaces().containsAll(offices));
@@ -404,10 +366,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getConstructionSites() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNConstructionSites(n);
-
         List<ConstructionSite> cs = p.getConstructionSites();
         assertEquals(n, cs.size());
         assertTrue(p.getCommunalPlaces().containsAll(cs));
@@ -415,10 +373,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getHospitals() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNHospitals(n);
-
         List<Hospital> hs = p.getAllHospitals();
         assertEquals(n, hs.size());
         assertTrue(p.getCommunalPlaces().containsAll(hs));
@@ -426,10 +380,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getNurseries() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNNurseries(n);
-
         List<Nursery> ns = p.getNurseries();
         assertEquals(n, ns.size());
         assertTrue(p.getCommunalPlaces().containsAll(ns));
@@ -437,10 +387,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getRestaurants() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNRestaurants(n);
-
         List<Restaurant> rs = p.getRestaurants();
         assertEquals(n, rs.size());
         assertTrue(p.getCommunalPlaces().containsAll(rs));
@@ -448,10 +394,6 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getSchools() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNSchools(n);
-
         List<School> ss = p.getSchools();
         assertEquals(n, ss.size());
         assertTrue(p.getCommunalPlaces().containsAll(ss));
@@ -459,11 +401,14 @@ public class PlacesTest extends SimulationTest {
 
     @Test
     public void getShops() {
-        int n = 1000;
-        Places p = new Places();
-        p.createNShops(n);
-
         List<Shop> ss = p.getShops();
+        assertEquals(n, ss.size());
+        assertTrue(p.getCommunalPlaces().containsAll(ss));
+    }
+
+    @Test
+    public void getCareHomes() {
+        List<CareHome> ss = p.getCareHomes();
         assertEquals(n, ss.size());
         assertTrue(p.getCommunalPlaces().containsAll(ss));
     }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PlacesTest.java
@@ -380,14 +380,14 @@ public class PlacesTest extends SimulationTest {
         p.createNConstructionSites(n);
         p.createNSchools(n);
 
-        assertEquals(n*7, p.getAllPlaces().size());
-        assertTrue(p.getAllPlaces().containsAll(p.getOffices()));
-        assertTrue(p.getAllPlaces().containsAll(p.getConstructionSites()));
-        assertTrue(p.getAllPlaces().containsAll(p.getAllHospitals()));
-        assertTrue(p.getAllPlaces().containsAll(p.getNurseries()));
-        assertTrue(p.getAllPlaces().containsAll(p.getRestaurants()));
-        assertTrue(p.getAllPlaces().containsAll(p.getSchools()));
-        assertTrue(p.getAllPlaces().containsAll(p.getShops()));
+        assertEquals(n*7, p.getCommunalPlaces().size());
+        assertTrue(p.getCommunalPlaces().containsAll(p.getOffices()));
+        assertTrue(p.getCommunalPlaces().containsAll(p.getConstructionSites()));
+        assertTrue(p.getCommunalPlaces().containsAll(p.getAllHospitals()));
+        assertTrue(p.getCommunalPlaces().containsAll(p.getNurseries()));
+        assertTrue(p.getCommunalPlaces().containsAll(p.getRestaurants()));
+        assertTrue(p.getCommunalPlaces().containsAll(p.getSchools()));
+        assertTrue(p.getCommunalPlaces().containsAll(p.getShops()));
 
     }
 
@@ -399,7 +399,7 @@ public class PlacesTest extends SimulationTest {
         
         List<Office> offices = p.getOffices();
         assertEquals(n, offices.size());
-        assertTrue(p.getAllPlaces().containsAll(offices));
+        assertTrue(p.getCommunalPlaces().containsAll(offices));
     }
 
     @Test
@@ -410,7 +410,7 @@ public class PlacesTest extends SimulationTest {
 
         List<ConstructionSite> cs = p.getConstructionSites();
         assertEquals(n, cs.size());
-        assertTrue(p.getAllPlaces().containsAll(cs));
+        assertTrue(p.getCommunalPlaces().containsAll(cs));
     }
 
     @Test
@@ -421,7 +421,7 @@ public class PlacesTest extends SimulationTest {
 
         List<Hospital> hs = p.getAllHospitals();
         assertEquals(n, hs.size());
-        assertTrue(p.getAllPlaces().containsAll(hs));
+        assertTrue(p.getCommunalPlaces().containsAll(hs));
     }
 
     @Test
@@ -432,7 +432,7 @@ public class PlacesTest extends SimulationTest {
 
         List<Nursery> ns = p.getNurseries();
         assertEquals(n, ns.size());
-        assertTrue(p.getAllPlaces().containsAll(ns));
+        assertTrue(p.getCommunalPlaces().containsAll(ns));
     }
 
     @Test
@@ -443,7 +443,7 @@ public class PlacesTest extends SimulationTest {
 
         List<Restaurant> rs = p.getRestaurants();
         assertEquals(n, rs.size());
-        assertTrue(p.getAllPlaces().containsAll(rs));
+        assertTrue(p.getCommunalPlaces().containsAll(rs));
     }
 
     @Test
@@ -454,7 +454,7 @@ public class PlacesTest extends SimulationTest {
 
         List<School> ss = p.getSchools();
         assertEquals(n, ss.size());
-        assertTrue(p.getAllPlaces().containsAll(ss));
+        assertTrue(p.getCommunalPlaces().containsAll(ss));
     }
 
     @Test
@@ -465,6 +465,6 @@ public class PlacesTest extends SimulationTest {
 
         List<Shop> ss = p.getShops();
         assertEquals(n, ss.size());
-        assertTrue(p.getAllPlaces().containsAll(ss));
+        assertTrue(p.getCommunalPlaces().containsAll(ss));
     }
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PopulationTest.java
@@ -238,7 +238,7 @@ public class PopulationTest extends SimulationTest {
 
     @Test
     public void allPlacesStaffed() {
-        for (CommunalPlace q : pop.getPlaces().getAllPlaces()) {
+        for (CommunalPlace q : pop.getPlaces().getCommunalPlaces()) {
             assertTrue("Place not fully staffed, nStaff: " + q.getnStaff(), q.isFullyStaffed());
         }
     }


### PR DESCRIPTION
This allows Places to manage all places rather than population managing some of them.

The PlacesTests can probably be refactored in the future to reduce some duplication, but suggest we leave these for now (since I think they are correct; if a little verbose). Chances are this will change as we get better place data.

There's also a bug fix in here to get the tests to run. Sometimes neighbours would take children to hospital instead of guardians.