### PR TITLE
Add additional metrics

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -189,6 +189,7 @@ public class Model {
             List<DailyStats> iterStats = p.simulate(nDays, contactsWriter);
             for (DailyStats s : iterStats) {
                 s.determineRValues(p);
+                s.determineFutureDeaths(p);
             }
 
             

--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -224,6 +224,7 @@ public class Model {
         // By here the output directory will be available
         CsvOutput.writeDailyStats(outP.resolve("out.csv"), iterId, s);
         CsvOutput.extraOutputsForThibaud(outP, s);
+        CsvOutput.writeDeathsByAge(outP, iterId, s);
         ParameterIO.writeParametersToFile(outP.resolve("population_params.json"));
         outputModelParams(outP.resolve("model_params.json"));
        

--- a/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
@@ -60,20 +60,16 @@ public class CsvOutput {
     }
 
     public static void writeDeathsByAge(Path outputDir, int startIter, List<List<DailyStats>> stats)  {
-        final String[] headers = {"iter", "age", "deaths"};
+        final String[] headers = {"iter", "day", "age", "deaths"};
         try {
             FileWriter file = new FileWriter(outputDir.resolve("deathsByAge.csv").toFile());
             CSVPrinter printer = new CSVPrinter(file, CSVFormat.DEFAULT.withHeader(headers));
 
             for (int i = 0; i < stats.size(); i++) {
-
-                Map<Integer, Integer> combinedDeathsByAge = new HashMap<>();
                 for (DailyStats s : stats.get(i)) {
-                    s.deathsByAge.forEach((k, v) -> combinedDeathsByAge.merge(k, v, Integer::sum));
-                }
-
-                for (Map.Entry<Integer, Integer> entry : combinedDeathsByAge.entrySet()) {
-                    printer.printRecord(startIter + i, entry.getKey(), entry.getValue());
+                    for (Map.Entry<Integer, Integer> entry : s.deathsByAge.entrySet()) {
+                        printer.printRecord(startIter + i, s.day.get(), entry.getKey(), entry.getValue());
+                    }
                 }
             }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
@@ -3,7 +3,9 @@ package uk.co.ramp.covid.simulation.output;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -57,6 +59,30 @@ public class CsvOutput {
             deathsCSV.close(true);
         } catch (IOException e) {
             LOGGER.error(e);
+        }
+    }
+
+    public static void writeDeathsByAge(Path outputDir, int startIter, List<List<DailyStats>> stats)  {
+        final String[] headers = {"iter", "age", "deaths"};
+        try {
+            FileWriter file = new FileWriter(outputDir.resolve("deathsByAge.csv").toFile());
+            CSVPrinter printer = new CSVPrinter(file, CSVFormat.DEFAULT.withHeader(headers));
+
+            for (int i = 0; i < stats.size(); i++) {
+
+                Map<Integer, Integer> combinedDeathsByAge = new HashMap<>();
+                for (DailyStats s : stats.get(i)) {
+                    s.deathsByAge.forEach((k, v) -> combinedDeathsByAge.merge(k, v, Integer::sum));
+                }
+
+                for (Map.Entry<Integer, Integer> entry : combinedDeathsByAge.entrySet()) {
+                    printer.printRecord(startIter + i, entry.getKey(), entry.getValue());
+                }
+            }
+
+            printer.close(true);
+        } catch (IOException e) {
+            LOGGER.error("Could not output deathsByAge");
         }
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
@@ -3,7 +3,6 @@ package uk.co.ramp.covid.simulation.output;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
@@ -16,14 +16,11 @@ public class CsvOutput {
     private static final Logger LOGGER = LogManager.getLogger(CsvOutput.class);
 
     public static void writeDailyStats(Appendable out, int startIterID, List<List<DailyStats>> stats) throws IOException {
-    final String[] headers = {"iter", "day", "H", "L", "A", "P1", "P2", "D", "R", "ISeed",
-                              "ICs_W","IHos_W","INur_W","IOff_W","IRes_W","ISch_W","ISho_W","ICHome_W",
-                              "IHome_I", "ICHome_R",
-                              "ICs_V","IHos_V","INur_V","IOff_V","IRes_V","ISch_V","ISho_V","IHome_V", "ITransport",
-                              "IAdu","IPen","IChi","IInf",
-                              "DAdul","DPen","DChi","DInf","DHome", "DHospital", "DCareHome", "DAdditional",
-                              "NumHospital", "HospitalisedToday",
-                              "SecInfections", "GenerationTime" };
+        if (stats.isEmpty() || stats.get(0).isEmpty()) {
+            return;
+        }
+
+        String[] headers = stats.get(0).get(0).csvHeaders().toArray(String[]::new);
         CSVPrinter printer = new CSVPrinter(out, CSVFormat.DEFAULT.withHeader(headers));
         for (int i = 0; i < stats.size(); i++) {
             for (DailyStats s : stats.get(i)) {

--- a/src/main/java/uk/co/ramp/covid/simulation/output/DailyStats.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/DailyStats.java
@@ -71,6 +71,7 @@ public class DailyStats {
     public IntValue careHomeDeaths = add("DCareHome");
     public IntValue additionalDeaths = add("DAdditional"); // Deaths in a workplace/school/etc
     public Map<Integer, Integer> deathsByAge = new HashMap<>();
+    public IntValue deathsAfterInfectionToday = add("DAfterInfectionToday");
 
     // Hospitalisation Stats
     public IntValue inHospital = add("NumHospital").log("Hospitalised");
@@ -210,5 +211,16 @@ public class DailyStats {
         RStats rs = new RStats(p);
         secInfections.set(rs.getSecInfections(day.get()));
         generationTime.set(rs.getMeanGenerationTime(day.get()));
+    }
+
+    // Operates on the population *after* a run to determine those who died and were infected
+    // on the day this DailyStats tracks
+    public void determineFutureDeaths(Population population) {
+        for (Person p : population.getAllPeople()) {
+            if (p.cStatus() == CStatus.DEAD
+                    && p.getcVirus().getInfectionLog().getInfectionTime().getAbsDay() == day.get()) {
+                deathsAfterInfectionToday.increment();
+            }
+        }
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/output/DailyStats.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/DailyStats.java
@@ -7,10 +7,8 @@ import uk.co.ramp.covid.simulation.population.CStatus;
 import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.Population;
 
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Stream;
-import java.util.ArrayList;
-import java.util.List;
 
 /** DailyStats accumulates statistics, e.g. healthy/dead, for a particular day */
 public class DailyStats {
@@ -72,6 +70,7 @@ public class DailyStats {
     public IntValue hospitalDeaths = add("DHospital");
     public IntValue careHomeDeaths = add("DCareHome");
     public IntValue additionalDeaths = add("DAdditional"); // Deaths in a workplace/school/etc
+    public Map<Integer, Integer> deathsByAge = new HashMap<>();
 
     // Hospitalisation Stats
     public IntValue inHospital = add("NumHospital").log("Hospitalised");

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -79,7 +79,7 @@ public abstract class Place {
 
     private void registerDeath(Person p, DailyStats stats) {
         reportDeath(stats);
-        p.reportDeath(stats);
+        p.recordDeath(stats);
     }
 
     protected double getTransConstant() {

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -51,7 +51,7 @@ public abstract class Person {
     private double lockdownHospitalApptAdjustment = 0.0;
 
     public abstract void reportInfection(DailyStats s);
-    public abstract void reportDeath (DailyStats s);
+    protected abstract void reportDeath (DailyStats s);
     public abstract void allocateCommunalPlace(Places p);
     
     private final double covidMortalityAgeAdjustment;
@@ -340,6 +340,11 @@ public abstract class Person {
             cVirus.getInfectionLog().registerInfected(t);
             s.seedInfections.increment();
         }
+    }
+    
+    public void recordDeath(DailyStats s) {
+        s.deathsByAge.merge(getAge(), 1, Integer::sum);
+        reportDeath(s);
     }
     
     public boolean hasMoved() {

--- a/src/test/java/uk/co/ramp/covid/simulation/output/CsvOutputTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/CsvOutputTest.java
@@ -42,7 +42,7 @@ public class CsvOutputTest extends SimulationTest {
                     + "IHome_I,ICHome_R,"
                     + "ICs_V,IHos_V,INur_V,IOff_V,IRes_V,ISch_V,ISho_V,IHome_V,ITransport,"
                     + "IAdu,IPen,IChi,IInf,"
-                    + "DAdul,DPen,DChi,DInf,DHome,DHospital,DCareHome,DAdditional,"
+                    + "DAdul,DPen,DChi,DInf,DHome,DHospital,DCareHome,DAdditional,DAfterInfectionToday,"
                     + "NumHospital,HospitalisedToday,SecInfections,GenerationTime";
             assertEquals("Wrong csv header", line, expectedHeader);
 
@@ -79,6 +79,7 @@ public class CsvOutputTest extends SimulationTest {
                         s.childDeaths, s.infantDeaths,
                         s.homeDeaths, s.hospitalDeaths,
                         s.careHomeDeaths, s.additionalDeaths,
+                        s.deathsAfterInfectionToday,
                         s.inHospital, s.newlyHospitalised,
                         s.secInfections,
                         s.generationTime

--- a/src/test/java/uk/co/ramp/covid/simulation/output/DailyStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/DailyStatsTest.java
@@ -8,7 +8,9 @@ import uk.co.ramp.covid.simulation.parameters.PopulationParameters;
 import uk.co.ramp.covid.simulation.testutil.SimulationTest;
 import uk.co.ramp.covid.simulation.util.Probability;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -205,6 +207,16 @@ public class DailyStatsTest extends SimulationTest {
                 totalAdditionalDeaths < totalHomeDeaths && totalAdditionalDeaths < totalHospitalDeaths);
         
         assertEquals("Inconsistent number of deaths", totalDeaths, actualDeaths);
+
+        // Test consistency in deathsByAge
+        Map<Integer, Integer> combinedDeathsByAge = new HashMap<>();
+        for (DailyStats s : stats.get(0)) {
+           s.deathsByAge.forEach((k, v) -> combinedDeathsByAge.merge(k, v, Integer::sum));
+        }
+
+        final int[] deathsByAge = {0};
+        combinedDeathsByAge.forEach((k, v) -> deathsByAge[0] += v);
+        assertEquals(totalDeaths, deathsByAge[0]);
     }
 
     //Test the equals() method in DailyStats

--- a/src/test/java/uk/co/ramp/covid/simulation/output/DailyStatsTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/DailyStatsTest.java
@@ -161,6 +161,13 @@ public class DailyStatsTest extends SimulationTest {
         assertNotEquals("Some people are hospitalised (new cases)", 0, newlyHospitalised);
         assertTrue("Hospitalised should be > newlyHospitalised", hospitalised > newlyHospitalised);
         assertTrue("Hospitalised <= phase2", newlyHospitalised <= totalPhase2);
+
+        // Test consistency of deaths by infection day
+        int totalInfectionsByDay = 0;
+        for (DailyStats s : stats.get(0)) {
+            totalInfectionsByDay += s.deathsAfterInfectionToday.get();
+        }
+        assertEquals(expDeaths, totalInfectionsByDay);
     }
 
     @Test


### PR DESCRIPTION
Adds support for:

1. Outputting a csv of age/death pairs. We output all pair separately instead of bucketing them in the model to give extra flexibility for future analysis (e.g. you can dig into a particular bucket without rerunning the simulation).

2. New column of DailyStats output that counts the number of people who eventually died that were *infected* on the given day.