### PR TITLE
Refactor output handling

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -221,9 +221,9 @@ public class Model {
         }
         
         // By here the output directory will be available
-        CsvOutput.writeDailyStats(outP.resolve("out.csv"), iterId, s);
-        CsvOutput.extraOutputsForThibaud(outP, s);
-        CsvOutput.writeDeathsByAge(outP, iterId, s);
+        CsvOutput output = new CsvOutput(outP, iterId, s);
+        output.writeOutput();
+
         ParameterIO.writeParametersToFile(outP.resolve("population_params.json"));
         outputModelParams(outP.resolve("model_params.json"));
        

--- a/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
@@ -14,6 +14,11 @@ import org.apache.logging.log4j.Logger;
 public class CsvOutput {
     private static final Logger LOGGER = LogManager.getLogger(CsvOutput.class);
 
+    private static final String STATS_FNAME = "out.csv";
+    private static final String INFECTIONS_OVER_TIME_FNAME = "dailyInfections.csv";
+    private static final String DEATHS_OVER_TIME_FNAME = "deaths.csv";
+    private static final String DEATHS_BY_AGE_FNAME = "deathsByAge.csv";
+
     public static void writeDailyStats(Appendable out, int startIterID, List<List<DailyStats>> stats) throws IOException {
         if (stats.isEmpty() || stats.get(0).isEmpty()) {
             return;
@@ -41,8 +46,10 @@ public class CsvOutput {
 
     public static void extraOutputsForThibaud(Path outputDir, List<List<DailyStats>> stats) {
         try {
-            CSVPrinter dailyInfectionsCSV = new CSVPrinter(new FileWriter(outputDir.resolve("dailyInfections.csv").toFile()), CSVFormat.DEFAULT);
-            CSVPrinter deathsCSV = new CSVPrinter(new FileWriter(outputDir.resolve("deaths.csv").toFile()), CSVFormat.DEFAULT);
+            CSVPrinter dailyInfectionsCSV = new CSVPrinter(
+                    new FileWriter(outputDir.resolve(INFECTIONS_OVER_TIME_FNAME).toFile()), CSVFormat.DEFAULT);
+            CSVPrinter deathsCSV = new CSVPrinter(
+                    new FileWriter(outputDir.resolve(DEATHS_OVER_TIME_FNAME).toFile()), CSVFormat.DEFAULT);
             for (int i = 0; i < stats.size(); i++) {
                 for (DailyStats s : stats.get(i)) {
                     dailyInfectionsCSV.print(s.getTotalDailyInfections());
@@ -61,7 +68,7 @@ public class CsvOutput {
     public static void writeDeathsByAge(Path outputDir, int startIter, List<List<DailyStats>> stats)  {
         final String[] headers = {"iter", "day", "age", "deaths"};
         try {
-            FileWriter file = new FileWriter(outputDir.resolve("deathsByAge.csv").toFile());
+            FileWriter file = new FileWriter(outputDir.resolve(DEATHS_BY_AGE_FNAME).toFile());
             CSVPrinter printer = new CSVPrinter(file, CSVFormat.DEFAULT.withHeader(headers));
 
             for (int i = 0; i < stats.size(); i++) {

--- a/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
@@ -18,6 +18,22 @@ public class CsvOutput {
     private static final String INFECTIONS_OVER_TIME_FNAME = "dailyInfections.csv";
     private static final String DEATHS_OVER_TIME_FNAME = "deaths.csv";
     private static final String DEATHS_BY_AGE_FNAME = "deathsByAge.csv";
+    
+    private Path outputDir;
+    private List<List<DailyStats>> stats;
+    private int startIteration;
+
+    public CsvOutput(Path outputDir, int startIteration, List<List<DailyStats>> modelStats) {
+        this.outputDir = outputDir;
+        this.startIteration = startIteration;
+        this.stats = modelStats;
+    }
+    
+    public void writeOutput() {
+        writeDailyStats(outputDir, startIteration, stats);
+        extraOutputsForThibaud(outputDir, stats);
+        writeDeathsByAge(outputDir, startIteration, stats);
+    }
 
     public static void writeDailyStats(Appendable out, int startIterID, List<List<DailyStats>> stats) throws IOException {
         if (stats.isEmpty() || stats.get(0).isEmpty()) {
@@ -36,7 +52,7 @@ public class CsvOutput {
     
     public static void writeDailyStats(Path outF, int startIterID, List<List<DailyStats>> stats) {
         try {
-            FileWriter out = new FileWriter(outF.toFile());
+            FileWriter out = new FileWriter(outF.resolve(STATS_FNAME).toFile());
             writeDailyStats(out, startIterID, stats);
             out.close();
         } catch (IOException e) {

--- a/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/CsvOutput.java
@@ -40,7 +40,8 @@ public class CsvOutput {
             extraOutputsForThibaud();
             writeDeathsByAge();
         } else {
-            LOGGER.warn("Trying to output csv files, but no output directory was set");
+            LOGGER.error("Trying to output csv files, but no output directory was set");
+            throw new ModelOutputException("Could not write csv stats output. No output directory was set");
         }
     }
 
@@ -69,14 +70,9 @@ public class CsvOutput {
         }
     }
     
-    public String dailyStatsAsCSVString() {
+    public String dailyStatsAsCSVString() throws IOException {
         StringWriter sw = new StringWriter();
-        try {
-            writeDailyStats(sw);
-        } catch (IOException e) {
-            LOGGER.warn("Could not convert DailyStats to CSV string");
-            return "";
-        }
+        writeDailyStats(sw);
         return sw.toString();
     }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/output/ModelOutputException.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/output/ModelOutputException.java
@@ -1,0 +1,7 @@
+package uk.co.ramp.covid.simulation.output;
+
+public class ModelOutputException extends RuntimeException {
+    public ModelOutputException(String s) {
+        super(s);
+    }
+}

--- a/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/ModelTest.java
@@ -13,7 +13,6 @@ import uk.co.ramp.covid.simulation.parameters.ParameterIO;
 import uk.co.ramp.covid.simulation.util.Time;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -130,16 +129,15 @@ public class ModelTest {
     @Ignore("this regression test is not kept up-to-date")
     @Test
     public void csvOutputRegressionTest() throws IOException {
-
-        StringWriter sw = new StringWriter();
-        CsvOutput.writeDailyStats(sw, 0, cachedStats);
+        CsvOutput output = new CsvOutput(0, cachedStats);
+        String csv = output.dailyStatsAsCSVString();
 
         Path expectedCsvPath = Paths.get("src/test/resources/regression_test_out.csv");
         // To update test data: Files.writeString(expectedCsvPath, sw.toString());
         String expectedCsvContents = new String(
                 Files.readAllBytes(expectedCsvPath), StandardCharsets.UTF_8);
 
-        assertEquals(expectedCsvContents, sw.toString());
+        assertEquals(expectedCsvContents, csv);
     }
 
     @Test

--- a/src/test/java/uk/co/ramp/covid/simulation/output/CsvOutputTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/output/CsvOutputTest.java
@@ -3,7 +3,6 @@ package uk.co.ramp.covid.simulation.output;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,9 +30,9 @@ public class CsvOutputTest extends SimulationTest {
         int startIterID = 2;
         List<List<DailyStats>> stats = m.run(startIterID);        
         
-        StringWriter sw = new StringWriter();
-        CsvOutput.writeDailyStats(sw, startIterID, stats);
-        StringReader sr = new StringReader(sw.toString());
+        CsvOutput output = new CsvOutput(startIterID, stats);
+        String csv = output.dailyStatsAsCSVString();
+        StringReader sr = new StringReader(csv);
         
         try (BufferedReader br = new BufferedReader(sr)) {
             String line = br.readLine();


### PR DESCRIPTION
Make output more extensible by reducing the number of static function calls.

We might want to generalise this a bit again to allow string csv output for each type (daily deaths etc), rather than just the main stats, but since we don't use them yet I've decided not to touch them.