### PR TITLE
Ensure serialisation is roud-trippable and improve Time serialisation

### DIFF
--- a/parameters/example_model_params_lockdown.json
+++ b/parameters/example_model_params_lockdown.json
@@ -9,44 +9,44 @@
     "lockdownEvents": [
         {
             "type" : "FullLockdown",
-            "start": 56,
+            "startDay": 56,
             "socialDistance": 0.5
         },
         {
             "type": "ConstructionSiteEasing",
-            "start": 96,
+            "startDay": 96,
             "socialDistance": 0.75,
             "keyPremises": 0.75
         },
         {
             "type": "ShopEasing",
-            "start": 126,
+            "startDay": 126,
             "socialDistance": 0.75,
             "keyPremises": 0.75,
             "visitFrequencyAdjustment": 0.75
         },
         {
             "type": "SchoolEasing",
-            "start": 175,
+            "startDay": 175,
             "socialDistance": 1.0,
             "keyPremises": 1.0,
             "pAttendsSchool": 0.5
         },
         {
             "type": "SchoolEasing",
-            "start": 225,
+            "startDay": 225,
             "socialDistance": 1.0,
             "keyPremises": 1.0,
             "pAttendsSchool": 1.0
         },
         {
             "type": "TravelEasing",
-            "start": 200,
+            "startDay": 200,
             "pTravelSeed": 0.000001
         },
         {
             "type": "ShieldingEasing",
-            "start": 180,
+            "startDay": 180,
             "partial": true,
             "partialShieldProbability": 0.4
         }
@@ -54,7 +54,7 @@
     "lockdownGenerators": [
         {
             "type": "LocalLockdownEventGenerator",
-            "start": 200,
+            "startDay": 200,
             "newCasesThreshold": 0.0001,
             "numHospitalisedThreshold": 200,
             "socialDistance": 1.0

--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -184,7 +184,7 @@
             "pLeaveShopHour": 0.5,
             "pLeaveRestaurantHour": 0.4,
             "schoolHolidays": [
-                { "start": 28, "end": 32 }
+                { "startDay": 28, "endDay": 32 }
             ]
         },
         "infantProperties":{

--- a/parameters/implementation/example_model_params_lothian.json
+++ b/parameters/implementation/example_model_params_lothian.json
@@ -9,70 +9,70 @@
     "lockdownEvents": [
         {
             "type" : "FullLockdown",
-            "start": 56,
+            "startDay": 56,
             "socialDistance": 0.4
         },
         {
             "type": "ConstructionSiteEasing",
-            "start": 86,
+            "startDay": 86,
             "socialDistance": 0.5,
             "keyPremises": 0.5
         },
         {
           "type": "HouseholdEasing",
-          "start": 116,
+          "startDay": 116,
           "neighbourVisitAdjustment": 0.5
         },
         {
             "type": "ConstructionSiteEasing",
-            "start": 116,
+            "startDay": 116,
             "socialDistance": 0.5,
             "keyPremises": 0.75
         },
         {
             "type": "ShopEasing",
-            "start": 116,
+            "startDay": 116,
             "socialDistance": 0.5,
             "keyPremises": 0.5,
             "visitFrequencyAdjustment": 0.5
         },
         {
             "type": "RestaurantEasing",
-            "start": 116,
+            "startDay": 116,
             "socialDistance": 0.2,
             "keyPremises": 0.25,
             "visitFrequencyAdjustment": 0.25
         },
         {
             "type": "ConstructionSiteEasing",
-            "start": 146,
+            "startDay": 146,
             "socialDistance": 0.75,
             "keyPremises": 1.0
         },
         {
             "type": "ShopEasing",
-            "start": 146,
+            "startDay": 146,
             "socialDistance": 0.5,
             "keyPremises": 0.75,
             "visitFrequencyAdjustment": 0.75
         },
         {
             "type": "RestaurantEasing",
-            "start": 146,
+            "startDay": 146,
             "socialDistance": 0.2,
             "keyPremises": 0.5,
             "visitFrequencyAdjustment": 0.5
         },
         {
             "type": "SchoolEasing",
-            "start": 205,
+            "startDay": 205,
             "socialDistance": 1.0,
             "keyPremises": 1.0,
             "pAttendsSchool": 0.5
         },
         {
             "type": "SchoolEasing",
-            "start": 225,
+            "startDay": 225,
             "socialDistance": 1.0,
             "keyPremises": 1.0,
             "pAttendsSchool": 1.0

--- a/src/main/java/uk/co/ramp/covid/simulation/Model.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/Model.java
@@ -229,6 +229,12 @@ public class Model {
        
     }
 
+    public String modelToJsonString() {
+        Writer writer = new StringWriter();
+        ParameterIO.getGson().toJson(this, writer);
+        return writer.toString();
+    }
+
     private void outputModelParams(Path outF) {
         try (Writer writer = new FileWriter(outF.toFile())) {
             ParameterIO.getGson().toJson(this, writer);
@@ -243,10 +249,38 @@ public class Model {
         return ParameterIO.getGson().fromJson(file, Model.class);
     }
 
+    public static Model readModelFromString(String json) throws JsonParseException {
+        Reader file = new StringReader(json);
+        return ParameterIO.getGson().fromJson(file, Model.class);
+    }
+
     public void optionallyGenerateRNGSeed() {
         if (rngSeed == null) {
             rngSeed = RNG.generateRandomSeed();
             LOGGER.warn("Generated RNG seed: " + rngSeed);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Model model = (Model) o;
+        return outputDisabled == model.outputDisabled &&
+                Objects.equals(populationSize, model.populationSize) &&
+                Objects.equals(nInitialInfections, model.nInitialInfections) &&
+                Objects.equals(externalInfectionDays, model.externalInfectionDays) &&
+                Objects.equals(nDays, model.nDays) &&
+                Objects.equals(nIters, model.nIters) &&
+                Objects.equals(rngSeed, model.rngSeed) &&
+                Objects.equals(outputDirectory, model.outputDirectory) &&
+                Objects.equals(networkOutputDir, model.networkOutputDir) &&
+                Objects.equals(lockdownEvents, model.lockdownEvents) &&
+                Objects.equals(lockdownGenerators, model.lockdownGenerators);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(outputDisabled, populationSize, nInitialInfections, externalInfectionDays, nDays, nIters, rngSeed, outputDirectory, networkOutputDir, lockdownEvents, lockdownGenerators);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/FullLockdownEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/FullLockdownEvent.java
@@ -7,6 +7,8 @@ import uk.co.ramp.covid.simulation.population.Person;
 import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.util.Time;
 
+import java.util.Objects;
+
 public class FullLockdownEvent extends LockdownEvent {
     
     private final Double socialDistance;
@@ -54,5 +56,18 @@ public class FullLockdownEvent extends LockdownEvent {
     @Override
     protected boolean isValid() {
         return start != null && socialDistance != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FullLockdownEvent that = (FullLockdownEvent) o;
+        return Objects.equals(socialDistance, that.socialDistance);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(socialDistance);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/FullLockdownEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/FullLockdownEvent.java
@@ -55,7 +55,7 @@ public class FullLockdownEvent extends LockdownEvent {
 
     @Override
     protected boolean isValid() {
-        return start != null && socialDistance != null;
+        return startDay != null && socialDistance != null;
     }
 
     @Override

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/LocalLockdownEventGenerator.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/LocalLockdownEventGenerator.java
@@ -7,6 +7,7 @@ import uk.co.ramp.covid.simulation.util.Time;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class LocalLockdownEventGenerator extends LockdownEventGenerator {
     private static final Logger LOGGER = LogManager.getLogger(LocalLockdownEventGenerator.class);
@@ -86,5 +87,22 @@ public class LocalLockdownEventGenerator extends LockdownEventGenerator {
                 && newCasesThreshold != null
                 && numHospitalisedThreshold != null
                 && socialDistance != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LocalLockdownEventGenerator that = (LocalLockdownEventGenerator) o;
+        return prevInfected == that.prevInfected &&
+                gotInitialInfections == that.gotInitialInfections &&
+                Objects.equals(newCasesThreshold, that.newCasesThreshold) &&
+                Objects.equals(numHospitalisedThreshold, that.numHospitalisedThreshold) &&
+                Objects.equals(socialDistance, that.socialDistance);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(newCasesThreshold, numHospitalisedThreshold, socialDistance, prevInfected, gotInitialInfections);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownController.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownController.java
@@ -41,7 +41,7 @@ public class LockdownController {
             c.handleLockdown(now);
 
             // Remove events that should never fire again
-            if (c.start.equals(now)) {
+            if (c.startDay.equals(now)) {
                 finished.add(c);
             }
         }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownEvent.java
@@ -5,6 +5,8 @@ import org.apache.logging.log4j.Logger;
 import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.util.Time;
 
+import java.util.Objects;
+
 public abstract class LockdownEvent {
     private static final Logger LOGGER = LogManager.getLogger(LockdownEvent.class);
 
@@ -33,5 +35,19 @@ public abstract class LockdownEvent {
     
     public void setPopulation(Population p) {
         population = p;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LockdownEvent that = (LockdownEvent) o;
+        return Objects.equals(start, that.start) &&
+                Objects.equals(population, that.population);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, population);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownEvent.java
@@ -10,19 +10,19 @@ import java.util.Objects;
 public abstract class LockdownEvent {
     private static final Logger LOGGER = LogManager.getLogger(LockdownEvent.class);
 
-    protected Time start;
+    protected Time startDay;
 
     // The Population we are controlling
     // Transient to avoid de-serialising this for now
     protected transient Population population;
 
     public LockdownEvent(Time start, Population p) {
-        this.start = start;
+        this.startDay = start;
         population = p;
     }
 
     public void handleLockdown(Time t) {
-        if (t.equals(start)) {
+        if (t.equals(startDay)) {
             LOGGER.info("Applying " + getName());
             apply();
         }
@@ -42,12 +42,12 @@ public abstract class LockdownEvent {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         LockdownEvent that = (LockdownEvent) o;
-        return Objects.equals(start, that.start) &&
+        return Objects.equals(startDay, that.startDay) &&
                 Objects.equals(population, that.population);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(start, population);
+        return Objects.hash(startDay, population);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownEventGenerator.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownEventGenerator.java
@@ -8,8 +8,8 @@ import java.util.Objects;
 
 /** Lockdown event generators do not control lockdowns themselves, but can conditionally generate events that do */
 public abstract class LockdownEventGenerator {
-    protected Time start = null;
-    protected Time end = null;
+    protected Time startDay = null;
+    protected Time endDay = null;
 
     // Transient to avoid de-serialisation
     protected transient Population population = null;
@@ -17,7 +17,7 @@ public abstract class LockdownEventGenerator {
     public LockdownEventGenerator() {}
     
     public List<LockdownEvent> generate(Time t) {
-        if (t.compareTo(start) >= 0 && (end == null || t.compareTo(end) < 0)) {
+        if (t.compareTo(startDay) >= 0 && (endDay == null || t.compareTo(endDay) < 0)) {
             return generateEvents(t);
         }
         return null;
@@ -26,7 +26,7 @@ public abstract class LockdownEventGenerator {
     protected abstract List<LockdownEvent> generateEvents(Time now);
 
     protected boolean isValid() {
-        return start != null;
+        return startDay != null;
     }
     
     public void setPopulation(Population p) {
@@ -38,13 +38,13 @@ public abstract class LockdownEventGenerator {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         LockdownEventGenerator that = (LockdownEventGenerator) o;
-        return Objects.equals(start, that.start) &&
-                Objects.equals(end, that.end) &&
+        return Objects.equals(startDay, that.startDay) &&
+                Objects.equals(endDay, that.endDay) &&
                 Objects.equals(population, that.population);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(start, end, population);
+        return Objects.hash(startDay, endDay, population);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownEventGenerator.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/LockdownEventGenerator.java
@@ -4,6 +4,7 @@ import uk.co.ramp.covid.simulation.util.Time;
 import uk.co.ramp.covid.simulation.population.Population;
 
 import java.util.List;
+import java.util.Objects;
 
 /** Lockdown event generators do not control lockdowns themselves, but can conditionally generate events that do */
 public abstract class LockdownEventGenerator {
@@ -31,5 +32,19 @@ public abstract class LockdownEventGenerator {
     public void setPopulation(Population p) {
         population = p;
     }
-    
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LockdownEventGenerator that = (LockdownEventGenerator) o;
+        return Objects.equals(start, that.start) &&
+                Objects.equals(end, that.end) &&
+                Objects.equals(population, that.population);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end, population);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/CommunalPlaceEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/CommunalPlaceEasingEvent.java
@@ -34,7 +34,7 @@ public abstract class CommunalPlaceEasingEvent extends LockdownEvent {
 
     @Override
     protected boolean isValid() {
-        return start != null
+        return startDay != null
                 && keyPremises != null
                 && socialDistance != null;
     }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/CommunalPlaceEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/CommunalPlaceEasingEvent.java
@@ -7,6 +7,7 @@ import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.Time;
 
 import java.util.List;
+import java.util.Objects;
 
 /** Lockdown component to ease restrictions on places */
 public abstract class CommunalPlaceEasingEvent extends LockdownEvent {
@@ -36,5 +37,20 @@ public abstract class CommunalPlaceEasingEvent extends LockdownEvent {
         return start != null
                 && keyPremises != null
                 && socialDistance != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        CommunalPlaceEasingEvent that = (CommunalPlaceEasingEvent) o;
+        return Objects.equals(keyPremises, that.keyPremises) &&
+                Objects.equals(socialDistance, that.socialDistance);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), keyPremises, socialDistance);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/HouseholdEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/HouseholdEasingEvent.java
@@ -5,6 +5,8 @@ import uk.co.ramp.covid.simulation.place.Household;
 import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.util.Time;
 
+import java.util.Objects;
+
 public class HouseholdEasingEvent extends LockdownEvent {
     
     private final Double neighbourVisitAdjustment;
@@ -29,5 +31,19 @@ public class HouseholdEasingEvent extends LockdownEvent {
     @Override
     protected boolean isValid() {
         return neighbourVisitAdjustment != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        HouseholdEasingEvent that = (HouseholdEasingEvent) o;
+        return Objects.equals(neighbourVisitAdjustment, that.neighbourVisitAdjustment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), neighbourVisitAdjustment);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/RestaurantEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/RestaurantEasingEvent.java
@@ -7,6 +7,7 @@ import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.Time;
 
 import java.util.List;
+import java.util.Objects;
 
 public class RestaurantEasingEvent extends CommunalPlaceEasingEvent {
 
@@ -38,5 +39,19 @@ public class RestaurantEasingEvent extends CommunalPlaceEasingEvent {
 
     protected boolean isValid() {
         return super.isValid() && visitFrequencyAdjustment != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        RestaurantEasingEvent that = (RestaurantEasingEvent) o;
+        return Objects.equals(visitFrequencyAdjustment, that.visitFrequencyAdjustment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), visitFrequencyAdjustment);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/SchoolEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/SchoolEasingEvent.java
@@ -8,6 +8,7 @@ import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.Time;
 
 import java.util.List;
+import java.util.Objects;
 
 public class SchoolEasingEvent extends CommunalPlaceEasingEvent {
     
@@ -48,5 +49,19 @@ public class SchoolEasingEvent extends CommunalPlaceEasingEvent {
     @Override
     protected boolean isValid() {
         return super.isValid() && pAttendsSchool != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        SchoolEasingEvent that = (SchoolEasingEvent) o;
+        return Objects.equals(pAttendsSchool, that.pAttendsSchool);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), pAttendsSchool);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/ShieldingEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/ShieldingEasingEvent.java
@@ -6,6 +6,8 @@ import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.Time;
 
+import java.util.Objects;
+
 public class ShieldingEasingEvent extends LockdownEvent {
 
     // Can either partially lift shielding, allowing neighbour visits, or lift it fully
@@ -41,5 +43,20 @@ public class ShieldingEasingEvent extends LockdownEvent {
     @Override
     protected boolean isValid() {
         return !partial || partialShieldProbability != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ShieldingEasingEvent that = (ShieldingEasingEvent) o;
+        return partial == that.partial &&
+                Objects.equals(partialShieldProbability, that.partialShieldProbability);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), partial, partialShieldProbability);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/ShopEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/ShopEasingEvent.java
@@ -7,6 +7,7 @@ import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.Time;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ShopEasingEvent extends CommunalPlaceEasingEvent {
     
@@ -38,5 +39,19 @@ public class ShopEasingEvent extends CommunalPlaceEasingEvent {
     
     protected boolean isValid() {
         return super.isValid() && visitFrequencyAdjustment != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ShopEasingEvent that = (ShopEasingEvent) o;
+        return Objects.equals(visitFrequencyAdjustment, that.visitFrequencyAdjustment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), visitFrequencyAdjustment);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/TravelEasingEvent.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/lockdown/easingevents/TravelEasingEvent.java
@@ -5,6 +5,8 @@ import uk.co.ramp.covid.simulation.population.Population;
 import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.Time;
 
+import java.util.Objects;
+
 public class TravelEasingEvent extends LockdownEvent {
     private final Probability pTravelSeed;
 
@@ -26,5 +28,19 @@ public class TravelEasingEvent extends LockdownEvent {
     @Override
     protected boolean isValid() {
         return pTravelSeed != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        TravelEasingEvent that = (TravelEasingEvent) o;
+        return Objects.equals(pTravelSeed, that.pTravelSeed);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), pTravelSeed);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/BuildingDistribution.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/BuildingDistribution.java
@@ -1,5 +1,7 @@
 package uk.co.ramp.covid.simulation.parameters;
 
+import java.util.Objects;
+
 /** Defines the number of types of building
  *
  *  Parameters such as populationToHospitalsRatio imply 1 hospital per populationToHospitalsRatio people
@@ -50,5 +52,34 @@ public class BuildingDistribution {
                 && nurserySizeDistribution.isValid()
                 && careHomeSizeDistribution.isValid()
                 && restaurantSizeDistribution.isValid();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BuildingDistribution that = (BuildingDistribution) o;
+        return Objects.equals(populationToHospitalsRatio, that.populationToHospitalsRatio) &&
+                Objects.equals(covidHospitalRatio, that.covidHospitalRatio) &&
+                Objects.equals(hospitalSizeDistribution, that.hospitalSizeDistribution) &&
+                Objects.equals(populationToSchoolsRatio, that.populationToSchoolsRatio) &&
+                Objects.equals(schoolSizeDistribution, that.schoolSizeDistribution) &&
+                Objects.equals(populationToShopsRatio, that.populationToShopsRatio) &&
+                Objects.equals(shopSizeDistribution, that.shopSizeDistribution) &&
+                Objects.equals(populationToOfficesRatio, that.populationToOfficesRatio) &&
+                Objects.equals(officeSizeDistribution, that.officeSizeDistribution) &&
+                Objects.equals(populationToConstructionSitesRatio, that.populationToConstructionSitesRatio) &&
+                Objects.equals(constructionSiteSizeDistribution, that.constructionSiteSizeDistribution) &&
+                Objects.equals(populationToNurseriesRatio, that.populationToNurseriesRatio) &&
+                Objects.equals(nurserySizeDistribution, that.nurserySizeDistribution) &&
+                Objects.equals(populationToRestaurantsRatio, that.populationToRestaurantsRatio) &&
+                Objects.equals(restaurantSizeDistribution, that.restaurantSizeDistribution) &&
+                Objects.equals(populationToCareHomesRatio, that.populationToCareHomesRatio) &&
+                Objects.equals(careHomeSizeDistribution, that.careHomeSizeDistribution);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(populationToHospitalsRatio, covidHospitalRatio, hospitalSizeDistribution, populationToSchoolsRatio, schoolSizeDistribution, populationToShopsRatio, shopSizeDistribution, populationToOfficesRatio, officeSizeDistribution, populationToConstructionSitesRatio, constructionSiteSizeDistribution, populationToNurseriesRatio, nurserySizeDistribution, populationToRestaurantsRatio, restaurantSizeDistribution, populationToCareHomesRatio, careHomeSizeDistribution);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/BuildingProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/BuildingProperties.java
@@ -4,6 +4,7 @@ import uk.co.ramp.covid.simulation.util.DateRange;
 import uk.co.ramp.covid.simulation.util.Probability;
 
 import java.util.List;
+import java.util.Objects;
 
 public class BuildingProperties {
     /** transmission constant for all places - adjusted based on number of expected interactions and number of people */
@@ -42,5 +43,34 @@ public class BuildingProperties {
             && schoolExpectedInteractionsPerHour >= 0
             && shopExpectedInteractionsPerHour >= 0
             && careHomeExpectedInteractionsPerHour >= 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BuildingProperties that = (BuildingProperties) o;
+        return Objects.equals(baseTransmissionConstant, that.baseTransmissionConstant) &&
+                Objects.equals(hospitalExpectedInteractionsPerHour, that.hospitalExpectedInteractionsPerHour) &&
+                Objects.equals(constructionSiteExpectedInteractionsPerHour, that.constructionSiteExpectedInteractionsPerHour) &&
+                Objects.equals(nurseryExpectedInteractionsPerHour, that.nurseryExpectedInteractionsPerHour) &&
+                Objects.equals(officeExpectedInteractionsPerHour, that.officeExpectedInteractionsPerHour) &&
+                Objects.equals(restaurantExpectedInteractionsPerHour, that.restaurantExpectedInteractionsPerHour) &&
+                Objects.equals(schoolExpectedInteractionsPerHour, that.schoolExpectedInteractionsPerHour) &&
+                Objects.equals(shopExpectedInteractionsPerHour, that.shopExpectedInteractionsPerHour) &&
+                Objects.equals(careHomeExpectedInteractionsPerHour, that.careHomeExpectedInteractionsPerHour) &&
+                Objects.equals(pHospitalKey, that.pHospitalKey) &&
+                Objects.equals(pConstructionSiteKey, that.pConstructionSiteKey) &&
+                Objects.equals(pOfficeKey, that.pOfficeKey) &&
+                Objects.equals(pShopKey, that.pShopKey) &&
+                Objects.equals(pLeaveShopHour, that.pLeaveShopHour) &&
+                Objects.equals(pLeaveRestaurantHour, that.pLeaveRestaurantHour) &&
+                Objects.equals(pHospitalStaffWillFurlough, that.pHospitalStaffWillFurlough) &&
+                Objects.equals(schoolHolidays, that.schoolHolidays);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(baseTransmissionConstant, hospitalExpectedInteractionsPerHour, constructionSiteExpectedInteractionsPerHour, nurseryExpectedInteractionsPerHour, officeExpectedInteractionsPerHour, restaurantExpectedInteractionsPerHour, schoolExpectedInteractionsPerHour, shopExpectedInteractionsPerHour, careHomeExpectedInteractionsPerHour, pHospitalKey, pConstructionSiteKey, pOfficeKey, pShopKey, pLeaveShopHour, pLeaveRestaurantHour, pHospitalStaffWillFurlough, schoolHolidays);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/CareHomeParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/CareHomeParameters.java
@@ -1,5 +1,7 @@
 package uk.co.ramp.covid.simulation.parameters;
 
+import java.util.Objects;
+
 public class CareHomeParameters {
     /** Adjustment in transmission rates for known cases to during staff interactions  */
     public Double PPETransmissionReduction = null;
@@ -11,5 +13,19 @@ public class CareHomeParameters {
     public boolean isValid() {
         return PPETransmissionReduction >= 0
                 && hoursAfterSymptomsBeforeQuarantine >= 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CareHomeParameters that = (CareHomeParameters) o;
+        return Objects.equals(PPETransmissionReduction, that.PPETransmissionReduction) &&
+                Objects.equals(hoursAfterSymptomsBeforeQuarantine, that.hoursAfterSymptomsBeforeQuarantine);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(PPETransmissionReduction, hoursAfterSymptomsBeforeQuarantine);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/CovidParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/CovidParameters.java
@@ -2,6 +2,8 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;
 
+import java.util.Objects;
+
 /**
  * CovidParameters is a singleton class for reading and storing the covid disease parameters
  *
@@ -46,4 +48,20 @@ public class CovidParameters {
                 && checker.isValid(hospitalisationParameters) && hospitalisationParameters.isValid();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CovidParameters that = (CovidParameters) o;
+        return Objects.equals(testParameters, that.testParameters) &&
+                Objects.equals(diseaseParameters, that.diseaseParameters) &&
+                Objects.equals(infectionSeedProperties, that.infectionSeedProperties) &&
+                Objects.equals(hospitalisationParameters, that.hospitalisationParameters) &&
+                Objects.equals(careHomeParameters, that.careHomeParameters);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(testParameters, diseaseParameters, infectionSeedProperties, hospitalisationParameters, careHomeParameters);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/CovidTestParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/CovidTestParameters.java
@@ -2,9 +2,25 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import uk.co.ramp.covid.simulation.util.Probability;
 
+import java.util.Objects;
+
 public class CovidTestParameters {
     public Probability pDiagnosticTestDetectsSuccessfully = null;
 
     /** Probability is it possible to be tested in a given hour */
     public Probability pDiagnosticTestAvailableHour = null;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CovidTestParameters that = (CovidTestParameters) o;
+        return Objects.equals(pDiagnosticTestDetectsSuccessfully, that.pDiagnosticTestDetectsSuccessfully) &&
+                Objects.equals(pDiagnosticTestAvailableHour, that.pDiagnosticTestAvailableHour);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pDiagnosticTestDetectsSuccessfully, pDiagnosticTestAvailableHour);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/DiseaseParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/DiseaseParameters.java
@@ -2,6 +2,8 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import uk.co.ramp.covid.simulation.util.Probability;
 
+import java.util.Objects;
+
 public class DiseaseParameters {
     public Double meanLatentPeriod = null;
     public Double sdLatentPeriod = null;
@@ -27,4 +29,38 @@ public class DiseaseParameters {
     /** Probabilities that a case goes to hospital when they eventually survive/die */
     public Probability pSurvivorGoesToHospital = null;
     public Probability pFatalityGoesToHospital = null;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DiseaseParameters that = (DiseaseParameters) o;
+        return Objects.equals(meanLatentPeriod, that.meanLatentPeriod) &&
+                Objects.equals(sdLatentPeriod, that.sdLatentPeriod) &&
+                Objects.equals(meanAsymptomaticPeriod, that.meanAsymptomaticPeriod) &&
+                Objects.equals(sdAsymptomaticPeriod, that.sdAsymptomaticPeriod) &&
+                Objects.equals(pSymptomaticCaseChild, that.pSymptomaticCaseChild) &&
+                Objects.equals(pSymptomaticCaseAdult, that.pSymptomaticCaseAdult) &&
+                Objects.equals(pSymptomaticCasePensioner, that.pSymptomaticCasePensioner) &&
+                Objects.equals(meanSymptomDelay, that.meanSymptomDelay) &&
+                Objects.equals(meanSymptomDelaySD, that.meanSymptomDelaySD) &&
+                Objects.equals(meanInfectiousDuration, that.meanInfectiousDuration) &&
+                Objects.equals(sdInfectiousDuration, that.sdInfectiousDuration) &&
+                Objects.equals(phase1Betaa, that.phase1Betaa) &&
+                Objects.equals(phase1Betab, that.phase1Betab) &&
+                Objects.equals(asymptomaticTransAdjustment, that.asymptomaticTransAdjustment) &&
+                Objects.equals(symptomaticTransAdjustment, that.symptomaticTransAdjustment) &&
+                Objects.equals(caseMortalityBase, that.caseMortalityBase) &&
+                Objects.equals(caseMortalityRate, that.caseMortalityRate) &&
+                Objects.equals(childProgressionPhase2, that.childProgressionPhase2) &&
+                Objects.equals(adultProgressionPhase2, that.adultProgressionPhase2) &&
+                Objects.equals(pensionerProgressionPhase2, that.pensionerProgressionPhase2) &&
+                Objects.equals(pSurvivorGoesToHospital, that.pSurvivorGoesToHospital) &&
+                Objects.equals(pFatalityGoesToHospital, that.pFatalityGoesToHospital);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(meanLatentPeriod, sdLatentPeriod, meanAsymptomaticPeriod, sdAsymptomaticPeriod, pSymptomaticCaseChild, pSymptomaticCaseAdult, pSymptomaticCasePensioner, meanSymptomDelay, meanSymptomDelaySD, meanInfectiousDuration, sdInfectiousDuration, phase1Betaa, phase1Betab, asymptomaticTransAdjustment, symptomaticTransAdjustment, caseMortalityBase, caseMortalityRate, childProgressionPhase2, adultProgressionPhase2, pensionerProgressionPhase2, pSurvivorGoesToHospital, pFatalityGoesToHospital);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/HospitalApptInfo.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/HospitalApptInfo.java
@@ -2,6 +2,8 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import uk.co.ramp.covid.simulation.util.Probability;
 
+import java.util.Objects;
+
 public class HospitalApptInfo {
     /** Daily probability that a person has an appt of a particular type */
     public Probability pInPatientDaily = null;
@@ -10,4 +12,20 @@ public class HospitalApptInfo {
 
     /** Expected length of inPatient appt (based on age) */
     public Double inPatientLengthDays = null;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HospitalApptInfo that = (HospitalApptInfo) o;
+        return Objects.equals(pInPatientDaily, that.pInPatientDaily) &&
+                Objects.equals(pOutPatientDaily, that.pOutPatientDaily) &&
+                Objects.equals(pDayCaseDaily, that.pDayCaseDaily) &&
+                Objects.equals(inPatientLengthDays, that.inPatientLengthDays);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pInPatientDaily, pOutPatientDaily, pDayCaseDaily, inPatientLengthDays);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/HospitalApptProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/HospitalApptProperties.java
@@ -1,5 +1,7 @@
 package uk.co.ramp.covid.simulation.parameters;
 
+import java.util.Objects;
+
 public class HospitalApptProperties {
     public Integer dayCaseStartTime = null;
     public Double meanDayCaseTime = null;
@@ -13,6 +15,27 @@ public class HospitalApptProperties {
 
     public boolean isValid() {
         return lockdownApptDecreasePercentage >= 0.0 && lockdownApptDecreasePercentage <= 1.0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HospitalApptProperties that = (HospitalApptProperties) o;
+        return Objects.equals(dayCaseStartTime, that.dayCaseStartTime) &&
+                Objects.equals(meanDayCaseTime, that.meanDayCaseTime) &&
+                Objects.equals(SDDayCaseTime, that.SDDayCaseTime) &&
+                Objects.equals(inPatientFirstStartTime, that.inPatientFirstStartTime) &&
+                Objects.equals(inPatientLastStartTime, that.inPatientLastStartTime) &&
+                Objects.equals(outPatientFirstStartTime, that.outPatientFirstStartTime) &&
+                Objects.equals(outPatientLastStartTime, that.outPatientLastStartTime) &&
+                Objects.equals(meanOutPatientTime, that.meanOutPatientTime) &&
+                Objects.equals(lockdownApptDecreasePercentage, that.lockdownApptDecreasePercentage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dayCaseStartTime, meanDayCaseTime, SDDayCaseTime, inPatientFirstStartTime, inPatientLastStartTime, outPatientFirstStartTime, outPatientLastStartTime, meanOutPatientTime, lockdownApptDecreasePercentage);
     }
 }
 

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/HospitalisationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/HospitalisationParameters.java
@@ -1,10 +1,25 @@
 package uk.co.ramp.covid.simulation.parameters;
 
+import java.util.Objects;
+
 public class HospitalisationParameters {
     /** Reduction to account for PPE when staff are visiting a known COVID case */
     public Double hospitalisationTransmissionReduction = null;
     
     public boolean isValid() {
         return hospitalisationTransmissionReduction >= 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HospitalisationParameters that = (HospitalisationParameters) o;
+        return Objects.equals(hospitalisationTransmissionReduction, that.hospitalisationTransmissionReduction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hospitalisationTransmissionReduction);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/HouseholdDistribution.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/HouseholdDistribution.java
@@ -5,6 +5,7 @@ import uk.co.ramp.covid.simulation.place.householdtypes.*;
 import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.ProbabilityDistribution;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 // Household populations
@@ -54,4 +55,26 @@ public class HouseholdDistribution {
         return householdTypeDistribution().isValid() && populationToHouseholdsRatio >= 1;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HouseholdDistribution that = (HouseholdDistribution) o;
+        return Objects.equals(populationToHouseholdsRatio, that.populationToHouseholdsRatio) &&
+                Objects.equals(pSingleAdult, that.pSingleAdult) &&
+                Objects.equals(pSmallAdult, that.pSmallAdult) &&
+                Objects.equals(pSingleParent, that.pSingleParent) &&
+                Objects.equals(pSmallFamily, that.pSmallFamily) &&
+                Objects.equals(pLargeTwoAdultFamily, that.pLargeTwoAdultFamily) &&
+                Objects.equals(pLargeManyAdultFamily, that.pLargeManyAdultFamily) &&
+                Objects.equals(pLargeAdult, that.pLargeAdult) &&
+                Objects.equals(pAdultPensioner, that.pAdultPensioner) &&
+                Objects.equals(pDoubleOlder, that.pDoubleOlder) &&
+                Objects.equals(pSingleOlder, that.pSingleOlder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(populationToHouseholdsRatio, pSingleAdult, pSmallAdult, pSingleParent, pSmallFamily, pLargeTwoAdultFamily, pLargeManyAdultFamily, pLargeAdult, pAdultPensioner, pDoubleOlder, pSingleOlder);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/HouseholdProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/HouseholdProperties.java
@@ -2,6 +2,8 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import uk.co.ramp.covid.simulation.util.Probability;
 
+import java.util.Objects;
+
 public class HouseholdProperties {
     /** Hourly probability visitors (including families) leave */
     public Probability pVisitorsLeaveHouseholdHour = null;
@@ -47,5 +49,32 @@ public class HouseholdProperties {
                 && neighbourClosingTime >= 0 && neighbourClosingTime < 24
                 && neighbourOpeningTime < neighbourClosingTime
                 && minShieldingAge >= 0 && minShieldingAge <= 100;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HouseholdProperties that = (HouseholdProperties) o;
+        return Objects.equals(pVisitorsLeaveHouseholdHour, that.pVisitorsLeaveHouseholdHour) &&
+                Objects.equals(householdVisitsNeighbourDaily, that.householdVisitsNeighbourDaily) &&
+                Objects.equals(expectedNeighbours, that.expectedNeighbours) &&
+                Objects.equals(pNeighbourFromSameGroup, that.pNeighbourFromSameGroup) &&
+                Objects.equals(pNeighbourFromOtherGroup, that.pNeighbourFromOtherGroup) &&
+                Objects.equals(pGoShoppingHour, that.pGoShoppingHour) &&
+                Objects.equals(lockdownShoppingProbabilityAdjustment, that.lockdownShoppingProbabilityAdjustment) &&
+                Objects.equals(pGoRestaurantHour, that.pGoRestaurantHour) &&
+                Objects.equals(householdIsolationPeriodDays, that.householdIsolationPeriodDays) &&
+                Objects.equals(pWillIsolate, that.pWillIsolate) &&
+                Objects.equals(pLockCompliance, that.pLockCompliance) &&
+                Objects.equals(neighbourOpeningTime, that.neighbourOpeningTime) &&
+                Objects.equals(neighbourClosingTime, that.neighbourClosingTime) &&
+                Objects.equals(minShieldingAge, that.minShieldingAge) &&
+                Objects.equals(pEntersShielding, that.pEntersShielding);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pVisitorsLeaveHouseholdHour, householdVisitsNeighbourDaily, expectedNeighbours, pNeighbourFromSameGroup, pNeighbourFromOtherGroup, pGoShoppingHour, lockdownShoppingProbabilityAdjustment, pGoRestaurantHour, householdIsolationPeriodDays, pWillIsolate, pLockCompliance, neighbourOpeningTime, neighbourClosingTime, minShieldingAge, pEntersShielding);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/InfantProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/InfantProperties.java
@@ -2,7 +2,22 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import uk.co.ramp.covid.simulation.util.Probability;
 
+import java.util.Objects;
+
 public class InfantProperties {
     /** Probability an infant attends nursery - fixed during the run */
     public Probability pAttendsNursery = null;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InfantProperties that = (InfantProperties) o;
+        return Objects.equals(pAttendsNursery, that.pAttendsNursery);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pAttendsNursery);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/InfectionSeedingProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/InfectionSeedingProperties.java
@@ -1,5 +1,7 @@
 package uk.co.ramp.covid.simulation.parameters;
 
+import java.util.Objects;
+
 public class InfectionSeedingProperties {
     /** Initial seed rates (per day) based on person type */
     public Double initialSeedAdult = null;
@@ -7,4 +9,19 @@ public class InfectionSeedingProperties {
 
     /** Daily increase in rates (power-law) */
     public Double rateIncreaseSeed = null;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InfectionSeedingProperties that = (InfectionSeedingProperties) o;
+        return Objects.equals(initialSeedAdult, that.initialSeedAdult) &&
+                Objects.equals(initialSeedInfantChildPensioner, that.initialSeedInfantChildPensioner) &&
+                Objects.equals(rateIncreaseSeed, that.rateIncreaseSeed);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(initialSeedAdult, initialSeedInfantChildPensioner, rateIncreaseSeed);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterIO.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterIO.java
@@ -29,19 +29,20 @@ public class ParameterIO {
     }
 
     /** Read population data from JSON file */
-    public static void readParametersFromFile(String path) throws IOException, JsonParseException {
-        Reader file = new FileReader(path);
-        ParameterIO r = getGson().fromJson(file, ParameterIO.class);
-
+    private static void readParameters(Reader reader) {
+        ParameterIO r = getGson().fromJson(reader, ParameterIO.class);
         CovidParameters.setParameters(r.disease);
         PopulationParameters.setParameters(r.population);
     }
 
+    public static void readParametersFromFile(String path) throws IOException, JsonParseException {
+        Reader r = new FileReader(path);
+        readParameters(r);
+    }
+
     public static void readParametersFromString(String json) throws JsonParseException {
-        Reader reader = new StringReader(json);
-        ParameterIO r = getGson().fromJson(reader, ParameterIO.class);
-        CovidParameters.setParameters(r.disease);
-        PopulationParameters.setParameters(r.population);
+        Reader r = new StringReader(json);
+        readParameters(r);
     }
 
     public static void writeParametersToFile(Path outF) {

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterIO.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/ParameterIO.java
@@ -37,6 +37,13 @@ public class ParameterIO {
         PopulationParameters.setParameters(r.population);
     }
 
+    public static void readParametersFromString(String json) throws JsonParseException {
+        Reader reader = new StringReader(json);
+        ParameterIO r = getGson().fromJson(reader, ParameterIO.class);
+        CovidParameters.setParameters(r.disease);
+        PopulationParameters.setParameters(r.population);
+    }
+
     public static void writeParametersToFile(Path outF) {
         ParameterIO params = new ParameterIO(CovidParameters.get(), PopulationParameters.get());
 
@@ -72,5 +79,12 @@ public class ParameterIO {
             lockdownGenerators.setGson(gson);
         } 
         return gson;
+    }
+
+    public static String writeParametersToString() {
+        ParameterIO params = new ParameterIO(CovidParameters.get(), PopulationParameters.get());
+        Writer writer = new StringWriter();
+        getGson().toJson(params, writer);
+        return writer.toString();
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/PensionerProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/PensionerProperties.java
@@ -2,6 +2,8 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import uk.co.ramp.covid.simulation.util.Probability;
 
+import java.util.Objects;
+
 public class PensionerProperties {
     /** Anyone >= minAgeToEnterCare may be assigned a CareHome with probability pEntersCareHome */
     public Integer minAgeToEnterCare = null;
@@ -9,5 +11,19 @@ public class PensionerProperties {
     
     public boolean isValid() {
         return minAgeToEnterCare >= 65 && minAgeToEnterCare <= 100;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PensionerProperties that = (PensionerProperties) o;
+        return Objects.equals(minAgeToEnterCare, that.minAgeToEnterCare) &&
+                Objects.equals(pEntersCareHome, that.pEntersCareHome);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(minAgeToEnterCare, pEntersCareHome);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/PersonProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/PersonProperties.java
@@ -2,6 +2,8 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import uk.co.ramp.covid.simulation.util.Probability;
 
+import java.util.Objects;
+
 public class PersonProperties {
     /** Chance a person will quarantine themselves if they develop symptoms */
     public Probability pQuarantinesIfSymptomatic = null;
@@ -17,5 +19,21 @@ public class PersonProperties {
         return symptomToQuarantineDelayHours >= 0
                 && symptomToTestingDelayHours >= 0
                 && susceptibleChildConstant >= 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PersonProperties that = (PersonProperties) o;
+        return Objects.equals(pQuarantinesIfSymptomatic, that.pQuarantinesIfSymptomatic) &&
+                Objects.equals(symptomToQuarantineDelayHours, that.symptomToQuarantineDelayHours) &&
+                Objects.equals(symptomToTestingDelayHours, that.symptomToTestingDelayHours) &&
+                Objects.equals(susceptibleChildConstant, that.susceptibleChildConstant);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pQuarantinesIfSymptomatic, symptomToQuarantineDelayHours, symptomToTestingDelayHours, susceptibleChildConstant);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/PlaceSizeDistribution.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/PlaceSizeDistribution.java
@@ -4,6 +4,8 @@ import uk.co.ramp.covid.simulation.place.CommunalPlace;
 import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.ProbabilityDistribution;
 
+import java.util.Objects;
+
 public class PlaceSizeDistribution {
     public Probability pSmall = null;
     public Probability pMed = null;
@@ -21,5 +23,18 @@ public class PlaceSizeDistribution {
         return sizeDistribution().isValid();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PlaceSizeDistribution that = (PlaceSizeDistribution) o;
+        return Objects.equals(pSmall, that.pSmall) &&
+                Objects.equals(pMed, that.pMed) &&
+                Objects.equals(pLarge, that.pLarge);
+    }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(pSmall, pMed, pLarge);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/PopulationParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/PopulationParameters.java
@@ -4,6 +4,7 @@ import uk.co.ramp.covid.simulation.util.InvalidParametersException;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * PopulationParameters is a singleton class for reading and storing the population parameters
@@ -87,5 +88,30 @@ public class PopulationParameters {
     }
     public static void clearParameters() {
         pp = null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PopulationParameters that = (PopulationParameters) o;
+        return Objects.equals(populationDistribution, that.populationDistribution) &&
+                Objects.equals(householdDistribution, that.householdDistribution) &&
+                Objects.equals(buildingDistribution, that.buildingDistribution) &&
+                Objects.equals(workerDistribution, that.workerDistribution) &&
+                Objects.equals(buildingProperties, that.buildingProperties) &&
+                Objects.equals(infantProperties, that.infantProperties) &&
+                Objects.equals(pensionerProperties, that.pensionerProperties) &&
+                Objects.equals(personProperties, that.personProperties) &&
+                Objects.equals(householdProperties, that.householdProperties) &&
+                Objects.equals(publicTransportParameters, that.publicTransportParameters) &&
+                Objects.equals(hospitalApptProperties, that.hospitalApptProperties) &&
+                Objects.equals(hospitalAppts, that.hospitalAppts) &&
+                Objects.equals(hospitalAppsParams, that.hospitalAppsParams);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(populationDistribution, householdDistribution, buildingDistribution, workerDistribution, buildingProperties, infantProperties, pensionerProperties, personProperties, householdProperties, publicTransportParameters, hospitalApptProperties, hospitalAppts, hospitalAppsParams);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/PublicTransportParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/PublicTransportParameters.java
@@ -2,6 +2,8 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import uk.co.ramp.covid.simulation.util.Probability;
 
+import java.util.Objects;
+
 public class PublicTransportParameters {
     /** Expected interactions on public transport */
     public Double expectedInteractions = null;
@@ -11,5 +13,19 @@ public class PublicTransportParameters {
 
     public boolean isValid() {
         return expectedInteractions >= 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PublicTransportParameters that = (PublicTransportParameters) o;
+        return Objects.equals(expectedInteractions, that.expectedInteractions) &&
+                Objects.equals(pFamilyTakesTransport, that.pFamilyTakesTransport);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expectedInteractions, pFamilyTakesTransport);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/WorkerDistribution.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/WorkerDistribution.java
@@ -4,6 +4,8 @@ import uk.co.ramp.covid.simulation.population.Adult;
 import uk.co.ramp.covid.simulation.util.Probability;
 import uk.co.ramp.covid.simulation.util.ProbabilityDistribution;
 
+import java.util.Objects;
+
 // Probability an Adult works in a particular job
 public class WorkerDistribution {
     /** Probabilities people work in particular jobs */
@@ -39,5 +41,27 @@ public class WorkerDistribution {
 
     public boolean isValid() {
         return professionDistribution().isValid();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WorkerDistribution that = (WorkerDistribution) o;
+        return Objects.equals(pOffice, that.pOffice) &&
+                Objects.equals(pShop, that.pShop) &&
+                Objects.equals(pHospital, that.pHospital) &&
+                Objects.equals(pConstruction, that.pConstruction) &&
+                Objects.equals(pTeacher, that.pTeacher) &&
+                Objects.equals(pRestaurant, that.pRestaurant) &&
+                Objects.equals(pUnemployed, that.pUnemployed) &&
+                Objects.equals(pNursery, that.pNursery) &&
+                Objects.equals(pCareHome, that.pCareHome) &&
+                Objects.equals(sizeAllocation, that.sizeAllocation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pOffice, pShop, pHospital, pConstruction, pTeacher, pRestaurant, pUnemployed, pNursery, pCareHome, sizeAllocation);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/util/DateRange.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/DateRange.java
@@ -7,37 +7,37 @@ import com.google.gson.JsonSerializer;
 import java.util.Objects;
 
 public class DateRange {
-    final Time start;
-    final Time end;
+    final Time startDay;
+    final Time endDay;
     
     public DateRange(Time start, Time end) {
-        this.start = start;
-        this.end = end;
+        this.startDay = start;
+        this.endDay = end;
     }
     
     public boolean inRange(Time t) {
-        return start.compareTo(t) <= 0 && end.compareTo(t) > 0;
+        return startDay.compareTo(t) <= 0 && endDay.compareTo(t) > 0;
     }
 
-    public Time getStart() {
-        return start;
+    public Time getStartDay() {
+        return startDay;
     }
 
-    public Time getEnd() {
-        return end;
+    public Time getEndDay() {
+        return endDay;
     }
 
     public static JsonSerializer<DateRange> serializer = (src, typeOfSrc, context) -> {
         JsonObject o = new JsonObject();
-        o.addProperty("start", src.getStart().getAbsDay());
-        o.addProperty("end", src.getEnd().getAbsDay());
+        o.addProperty("startDay", src.getStartDay().getAbsDay());
+        o.addProperty("endDay", src.getEndDay().getAbsDay());
         return o;
     };
 
     public static JsonDeserializer<DateRange> deserializer = (json, typeOfT, context) -> {
         JsonObject o = json.getAsJsonObject();
-        int s = o.get("start").getAsInt();
-        int e = o.get("end").getAsInt();
+        int s = o.get("startDay").getAsInt();
+        int e = o.get("endDay").getAsInt();
         return new DateRange(Time.timeFromDay(s), Time.timeFromDay(e));
     };
 
@@ -46,12 +46,12 @@ public class DateRange {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DateRange dateRange = (DateRange) o;
-        return Objects.equals(start, dateRange.start) &&
-                Objects.equals(end, dateRange.end);
+        return Objects.equals(startDay, dateRange.startDay) &&
+                Objects.equals(endDay, dateRange.endDay);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(start, end);
+        return Objects.hash(startDay, endDay);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/util/DateRange.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/DateRange.java
@@ -4,6 +4,8 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializer;
 
+import java.util.Objects;
+
 public class DateRange {
     final Time start;
     final Time end;
@@ -38,4 +40,18 @@ public class DateRange {
         int e = o.get("end").getAsInt();
         return new DateRange(Time.timeFromDay(s), Time.timeFromDay(e));
     };
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DateRange dateRange = (DateRange) o;
+        return Objects.equals(start, dateRange.start) &&
+                Objects.equals(end, dateRange.end);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/util/Probability.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/Probability.java
@@ -6,6 +6,8 @@ import com.google.gson.JsonSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Objects;
+
 public class Probability {
     private static final Logger LOGGER = LogManager.getLogger(Probability.class);
 
@@ -46,4 +48,17 @@ public class Probability {
 
     public static JsonSerializer<Probability> serializer =
             (src, typeOfSrc, context) -> new JsonPrimitive(src.asDouble());
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Probability that = (Probability) o;
+        return Double.compare(that.p, p) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(p);
+    }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/util/Time.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/util/Time.java
@@ -70,6 +70,10 @@ public class Time implements Comparable<Time> {
     };
 
     public static JsonSerializer<Time> serializer = (src, typeOfSrc, context) -> {
-        return new JsonPrimitive(src.getAbsDay());
+        if (src.getAbsTime() % 24 == 0) {
+            return new JsonPrimitive(src.getAbsDay());
+        } else {
+            throw new JsonIOException("Can not output a Time that is not a multiple of 24");
+        }
     };
 }

--- a/src/test/java/uk/co/ramp/covid/simulation/parameters/ParametersTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/parameters/ParametersTest.java
@@ -2,12 +2,12 @@ package uk.co.ramp.covid.simulation.parameters;
 
 import org.junit.After;
 import org.junit.Test;
+import uk.co.ramp.covid.simulation.Model;
 import uk.co.ramp.covid.simulation.util.InvalidParametersException;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ParametersTest {
 
@@ -29,6 +29,30 @@ public class ParametersTest {
     public void testNullParameters() {
         //Test that null parameters throw an InvalidParametersException
         PopulationParameters.get().isValid();
+    }
+
+    @Test
+    public void serialisationAndDeSerialisationAreInverse() throws IOException {
+        ParameterIO.readParametersFromFile("parameters/example_population_params.json");
+        PopulationParameters pop = PopulationParameters.get();
+        CovidParameters covid = CovidParameters.get();
+
+        String s = ParameterIO.writeParametersToString();
+
+        PopulationParameters.clearParameters();
+        CovidParameters.clearParameters();
+
+        ParameterIO.readParametersFromString(s);
+
+        assertTrue(pop.equals(PopulationParameters.get()));
+        assertTrue(covid.equals(CovidParameters.get()));
+
+        // Model checks
+        Model m = Model.readModelFromFile("parameters/example_model_params_lockdown.json");
+        s = m.modelToJsonString();
+        Model n = Model.readModelFromString(s);
+
+        assertTrue(m.equals(n));
     }
 
     @After


### PR DESCRIPTION
This fixes: https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/651 and https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/650

It looks like a lot of changes, but most of it is auto generated equals methods for the parameters. We do it this way since we can't guarantee the ordering/indentation of the JSON output so a string comparison isn't useful.