### PR TITLE
Fix overflow in network generation

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/population/Transport.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Transport.java
@@ -39,6 +39,7 @@ public class Transport extends Place {
     public void doInfect(Time t, DailyStats stats, ContactsWriter contactsWriter) {
         if (contactsWriter != null) {
             addContacts(t, contactsWriter);
+            people.clear();
             return; // don't do infections
         }
 


### PR DESCRIPTION
Small fix I noticed when reviewing Bob's new tests. 

We need to explicitly clear people from public transport since it's a special case of the movement system. Because we didn't the network generation had an integer overflow error.