### PR TITLE
Clarify age range parameters

### DIFF
--- a/parameters/example_population_params.json
+++ b/parameters/example_population_params.json
@@ -9,9 +9,9 @@
           "sdLatentPeriod":0.5,
           "meanAsymptomaticPeriod":192,
           "sdAsymptomaticPeriod":0.5,
-          "pSymptomaticCaseChild": 0.21,
-          "pSymptomaticCaseAdult": 0.5,
-          "pSymptomaticCasePensioner": 0.69,
+          "pSymptomaticCaseUnder21": 0.21,
+          "pSymptomaticCaseOver21": 0.5,
+          "pSymptomaticCaseOver70": 0.69,
           "meanSymptomDelay": -16.08,
           "meanSymptomDelaySD": 30,
           "meanInfectiousDuration": 321.6,
@@ -234,7 +234,7 @@
             "pEntersShielding": 0.8
         },
         "personProperties":{
-            "susceptibleChildConstant": 0.5,
+            "susceptibleUnder21Constant": 0.5,
             "pQuarantinesIfSymptomatic":0.9,
             "symptomToQuarantineDelayHours": 12,
             "symptomToTestingDelayHours": 24

--- a/src/main/java/uk/co/ramp/covid/simulation/covid/Covid.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/covid/Covid.java
@@ -51,13 +51,14 @@ public class Covid {
     }
      
     private void setSymptomatic() {
-        if(ccase.getAge() >= 70) {
+        if (ccase.getAge() >= 70) {
             // This is set to 70 and 20 because the paper form LSHTM that informed this use these cut-offs
-            symptomaticCase = CovidParameters.get().diseaseParameters.pSymptomaticCasePensioner.sample();
-        } else if(ccase.getAge() < 70 && ccase.getAge() > 20) {
-            symptomaticCase = CovidParameters.get().diseaseParameters.pSymptomaticCaseAdult.sample();
+            symptomaticCase = CovidParameters.get().diseaseParameters.pSymptomaticCaseOver70.sample();
+        } else if (ccase.getAge() < 70 && ccase.getAge() > 20) {
+            symptomaticCase = CovidParameters.get().diseaseParameters.pSymptomaticCaseOver21.sample();
+        } else {
+            symptomaticCase = CovidParameters.get().diseaseParameters.pSymptomaticCaseUnder21.sample();
         }
-        else symptomaticCase = CovidParameters.get().diseaseParameters.pSymptomaticCaseChild.sample();
     }
 
     // For each infection define the duration of the infection periods

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/DiseaseParameters.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/DiseaseParameters.java
@@ -9,9 +9,9 @@ public class DiseaseParameters {
     public Double sdLatentPeriod = null;
     public Double meanAsymptomaticPeriod = null;
     public Double sdAsymptomaticPeriod = null;
-    public Probability pSymptomaticCaseChild = null;
-    public Probability pSymptomaticCaseAdult = null;
-    public Probability pSymptomaticCasePensioner = null;
+    public Probability pSymptomaticCaseUnder21 = null;
+    public Probability pSymptomaticCaseOver21 = null;
+    public Probability pSymptomaticCaseOver70 = null;
     public Double meanSymptomDelay = null;
     public Double meanSymptomDelaySD = null;
     public Double meanInfectiousDuration = null;
@@ -39,9 +39,9 @@ public class DiseaseParameters {
                 Objects.equals(sdLatentPeriod, that.sdLatentPeriod) &&
                 Objects.equals(meanAsymptomaticPeriod, that.meanAsymptomaticPeriod) &&
                 Objects.equals(sdAsymptomaticPeriod, that.sdAsymptomaticPeriod) &&
-                Objects.equals(pSymptomaticCaseChild, that.pSymptomaticCaseChild) &&
-                Objects.equals(pSymptomaticCaseAdult, that.pSymptomaticCaseAdult) &&
-                Objects.equals(pSymptomaticCasePensioner, that.pSymptomaticCasePensioner) &&
+                Objects.equals(pSymptomaticCaseUnder21, that.pSymptomaticCaseUnder21) &&
+                Objects.equals(pSymptomaticCaseOver21, that.pSymptomaticCaseOver21) &&
+                Objects.equals(pSymptomaticCaseOver70, that.pSymptomaticCaseOver70) &&
                 Objects.equals(meanSymptomDelay, that.meanSymptomDelay) &&
                 Objects.equals(meanSymptomDelaySD, that.meanSymptomDelaySD) &&
                 Objects.equals(meanInfectiousDuration, that.meanInfectiousDuration) &&
@@ -61,6 +61,6 @@ public class DiseaseParameters {
 
     @Override
     public int hashCode() {
-        return Objects.hash(meanLatentPeriod, sdLatentPeriod, meanAsymptomaticPeriod, sdAsymptomaticPeriod, pSymptomaticCaseChild, pSymptomaticCaseAdult, pSymptomaticCasePensioner, meanSymptomDelay, meanSymptomDelaySD, meanInfectiousDuration, sdInfectiousDuration, phase1Betaa, phase1Betab, asymptomaticTransAdjustment, symptomaticTransAdjustment, caseMortalityBase, caseMortalityRate, childProgressionPhase2, adultProgressionPhase2, pensionerProgressionPhase2, pSurvivorGoesToHospital, pFatalityGoesToHospital);
+        return Objects.hash(meanLatentPeriod, sdLatentPeriod, meanAsymptomaticPeriod, sdAsymptomaticPeriod, pSymptomaticCaseUnder21, pSymptomaticCaseOver21, pSymptomaticCaseOver70, meanSymptomDelay, meanSymptomDelaySD, meanInfectiousDuration, sdInfectiousDuration, phase1Betaa, phase1Betab, asymptomaticTransAdjustment, symptomaticTransAdjustment, caseMortalityBase, caseMortalityRate, childProgressionPhase2, adultProgressionPhase2, pensionerProgressionPhase2, pSurvivorGoesToHospital, pFatalityGoesToHospital);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/parameters/PersonProperties.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/parameters/PersonProperties.java
@@ -13,12 +13,12 @@ public class PersonProperties {
     public Integer symptomToTestingDelayHours = null;
 
     /** Under 20s susceptibility constant */
-    public Double susceptibleChildConstant = null;
+    public Double susceptibleUnder21Constant = null;
     
     public boolean isValid() {
         return symptomToQuarantineDelayHours >= 0
                 && symptomToTestingDelayHours >= 0
-                && susceptibleChildConstant >= 0;
+                && susceptibleUnder21Constant >= 0;
     }
 
     @Override
@@ -29,11 +29,11 @@ public class PersonProperties {
         return Objects.equals(pQuarantinesIfSymptomatic, that.pQuarantinesIfSymptomatic) &&
                 Objects.equals(symptomToQuarantineDelayHours, that.symptomToQuarantineDelayHours) &&
                 Objects.equals(symptomToTestingDelayHours, that.symptomToTestingDelayHours) &&
-                Objects.equals(susceptibleChildConstant, that.susceptibleChildConstant);
+                Objects.equals(susceptibleUnder21Constant, that.susceptibleUnder21Constant);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(pQuarantinesIfSymptomatic, symptomToQuarantineDelayHours, symptomToTestingDelayHours, susceptibleChildConstant);
+        return Objects.hash(pQuarantinesIfSymptomatic, symptomToQuarantineDelayHours, symptomToTestingDelayHours, susceptibleUnder21Constant);
     }
 }

--- a/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/population/Person.java
@@ -70,7 +70,7 @@ public abstract class Person {
         
         if(age <= 20) {
             // The original paper gave parameters broken at age 20
-            this.covidSusceptibleVal = PopulationParameters.get().personProperties.susceptibleChildConstant;
+            this.covidSusceptibleVal = PopulationParameters.get().personProperties.susceptibleUnder21Constant;
         } else {
             this.covidSusceptibleVal = 1.0;
         }
@@ -83,10 +83,11 @@ public abstract class Person {
     }
     
     public double setMortality() {
-    	double out = 0.0;
-    	if(age > 50) out = Math.pow((((double) age - 50.0) / 50.0) + CovidParameters.get().diseaseParameters.caseMortalityBase, 2.0);
-    	else out = CovidParameters.get().diseaseParameters.caseMortalityBase;
-    	return out;
+    	if(age > 50) {
+    	    return Math.pow((((double) age - 50.0) / 50.0) + CovidParameters.get().diseaseParameters.caseMortalityBase, 2.0);
+        } else {
+    	    return CovidParameters.get().diseaseParameters.caseMortalityBase;
+        }
     }
     
     public void setWillBeHospitalised() {

--- a/src/test/java/uk/co/ramp/covid/simulation/covid/CovidTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/covid/CovidTest.java
@@ -24,7 +24,7 @@ public class CovidTest extends SimulationTest {
     public void testStepInfectionSymptomatic() {
         //Use the default parameters with a mortality rate of 100
         CovidParameters.get().diseaseParameters.caseMortalityRate = 1.0;
-        CovidParameters.get().diseaseParameters.pSymptomaticCasePensioner = new Probability(1.0);
+        CovidParameters.get().diseaseParameters.pSymptomaticCaseOver70 = new Probability(1.0);
         CovidParameters.get().diseaseParameters.pensionerProgressionPhase2 = 100.0;
 
         Person pensioner = new Pensioner(85, Person.Sex.MALE);
@@ -85,7 +85,7 @@ public class CovidTest extends SimulationTest {
     //Test that a child steps through the infection from Asymtomatic to recovered
     @Test
     public void testStepInfectionAsymptomatic() {
-        CovidParameters.get().diseaseParameters.pSymptomaticCaseAdult = new Probability(0);
+        CovidParameters.get().diseaseParameters.pSymptomaticCaseOver21 = new Probability(0);
         Person child = new Child(5, Person.Sex.FEMALE);
         Time t = new Time();
         Covid virus = new Covid(child);

--- a/src/test/java/uk/co/ramp/covid/simulation/place/CareHomeTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/place/CareHomeTest.java
@@ -72,7 +72,7 @@ public class CareHomeTest extends SimulationTest {
         PopulationParameters.get().pensionerProperties.pEntersCareHome = new Probability(0.8);
         // There can be lots of people in the care home so we crank this up to avoid getting almost 0 transmission probs
         PopulationParameters.get().buildingProperties.careHomeExpectedInteractionsPerHour = 100.0;
-        CovidParameters.get().diseaseParameters.pSymptomaticCasePensioner = new Probability(1.0);
+        CovidParameters.get().diseaseParameters.pSymptomaticCaseOver70 = new Probability(1.0);
         CovidParameters.get().diseaseParameters.pensionerProgressionPhase2 = 100.0;
         // Makes it less likely we get symptoms before we are infectious
         CovidParameters.get().diseaseParameters.meanSymptomDelay = 0.1;


### PR DESCRIPTION
Fixes: https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/648

The "setMortality()" function for over 50's is still a bit hidden since it's not driven by a parameter. It's not particularly clear what to do about this, so I suggest we just make the easy parameter name changes for now and come back to it if required.