### PR TITLE
Demonstrate strange behaviour in Person.setMortality()

### DIFF
--- a/src/test/java/uk/co/ramp/covid/simulation/population/PersonTest.java
+++ b/src/test/java/uk/co/ramp/covid/simulation/population/PersonTest.java
@@ -46,5 +46,21 @@ public class PersonTest extends SimulationTest {
 
     }
 
+    @Test
+    public void testSetMortality() {
+        double m10 = new Child(10, Person.Sex.MALE).setMortality();
+        double m50 = new Adult(50, Person.Sex.MALE).setMortality();
+        double m51 = new Adult(51, Person.Sex.MALE).setMortality();
+        double m80 = new Pensioner(80, Person.Sex.MALE).setMortality();
+        
+        double delta = 0.00001;
+
+        // This tests current behaviour,
+        //   but is probably _not_ all correct behaviour.
+        assertEquals(m10, 0.0500, delta);
+        assertEquals(m50, 0.0500, delta);
+        assertEquals(m51, 0.0049, delta);
+        assertEquals(m80, 0.4225, delta);
+    }
 
 }


### PR DESCRIPTION
This adds a test to demonstrate the current behaviour of setMortality, which appears to be dodgy.  This method returns `0.05` for ages <50, and then `0.0049` for age 51.