### PR TITLE
Fix integer overflow bug

### DIFF
--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -111,10 +111,24 @@ public abstract class Place {
         return pairs;
     }
 
+    private static int nextBinomial(RandomDataGenerator rng, long nPairs, double probability) {
+        if (nPairs < Integer.MAX_VALUE) {
+            return rng.nextBinomial((int)nPairs, probability);
+        } else {
+            // make an approximation for large numbers (because our RNG expects an int)
+            long scale = nPairs / Integer.MAX_VALUE;
+            long nContacts = rng.nextBinomial(Integer.MAX_VALUE, probability);
+            nContacts *= scale;
+
+            assert nContacts < Integer.MAX_VALUE;
+            return (int)nContacts;
+        }
+    }
+
     protected void addContacts(Time t, ContactsWriter contactsWriter) {
-        int nPairs = getNumPeople() * (getNumPeople() - 1) / 2;
-        int nContacts = rng.nextBinomial(nPairs, this.getTransConstant() / 24.0);
-        Collection<Pair<Integer, Integer>> randomPairs = genRandomPairs(0, people.size() - 1, nContacts);
+        long nPairs = (long) getNumPeople() * (getNumPeople() - 1) / 2;
+        int nContacts = nextBinomial(rng, nPairs, this.getTransConstant() / 24.0);
+        Collection<Pair<Integer, Integer>> randomPairs = genRandomPairs(0, getNumPeople() - 1, nContacts);
         for (Pair<Integer, Integer> pair : randomPairs) {
             contactsWriter.addContact(t, people.get(pair.getFirst()), people.get(pair.getSecond()), this, 1);
         }

--- a/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
+++ b/src/main/java/uk/co/ramp/covid/simulation/place/Place.java
@@ -111,18 +111,19 @@ public abstract class Place {
         return pairs;
     }
 
-    private static int nextBinomial(RandomDataGenerator rng, long nPairs, double probability) {
-        if (nPairs < Integer.MAX_VALUE) {
-            return rng.nextBinomial((int)nPairs, probability);
-        } else {
-            // make an approximation for large numbers (because our RNG expects an int)
-            long scale = nPairs / Integer.MAX_VALUE;
-            long nContacts = rng.nextBinomial(Integer.MAX_VALUE, probability);
-            nContacts *= scale;
+    // rng.nextBinomial() expects an integer - this method handles >Integer.MAX_VALUE trials 
+    private static int nextBinomial(RandomDataGenerator rng, long numberOfTrials, double probabilityOfSuccess) {
+        long result = 0;
+        long remainingTrials = numberOfTrials;
 
-            assert nContacts < Integer.MAX_VALUE;
-            return (int)nContacts;
+        while (remainingTrials > Integer.MAX_VALUE) {
+            result += rng.nextBinomial(Integer.MAX_VALUE, probabilityOfSuccess);
+            remainingTrials -= Integer.MAX_VALUE;
         }
+        result += rng.nextBinomial((int)remainingTrials, probabilityOfSuccess);
+
+        assert result < Integer.MAX_VALUE;
+        return (int)result;
     }
 
     protected void addContacts(Time t, ContactsWriter contactsWriter) {


### PR DESCRIPTION
This fixes a bug Sibylle found when generating a network for large populations.

When adding transport contacts (in network generator mode), the number of pairs passed to nextBinomial was a 32bit integer, but with larger populations it needs to be a 64bit integer. Since we are using an RNG which we can't easily change,
this quick fix adds a wrapper to rng.nextBinomial() which makes an approximation for large (>32bit) numbers of pairs.

(Any good ideas about how to add a good test for this new method would be welcome.)